### PR TITLE
Added delimited encoding for SzRecordId and proper error checking for entity-paths/entity-networks

### DIFF
--- a/src/main/java/com/senzing/api/model/SzRecordId.java
+++ b/src/main/java/com/senzing/api/model/SzRecordId.java
@@ -100,16 +100,53 @@ public class SzRecordId implements SzEntityIdentifier {
   }
 
   /**
-   * Parses the specified JSON text for the record ID.
+   * Parses the specified JSON text for the record ID.  Alternatively, instead
+   * of JSON text a delimited string can be specified with the first character
+   * is the delimiter and the characters after the first character and up to
+   * excluding the second occurrence of the delimiter are the data source and
+   * the characters after the second occurrence of the delimiter are the record
+   * ID.  For example the following are both valid for parsing:
+   * <ul>
+   *   <li><code>{"src":"PEOPLE", "id": "12345ABC"}</code></li>
+   *   <li><code>:PEOPLE:12345ABC</code></li>
+   * </ul>
    *
    * @param text The JSON text to parse.
    *
    * @return The {@link SzRecordId} that was created.
    */
   public static SzRecordId valueOf(String text) {
-    JsonObject  jsonObject  = JsonUtils.parseJsonObject(text);
-    String      source      = jsonObject.getString("src");
-    String      id          = jsonObject.getString("id");
-    return new SzRecordId(source, id);
+    RuntimeException failure = null;
+    text = text.trim();
+    int length = text.length();
+
+    // first try to parse as JSON
+    if (length > 2 && text.charAt(0) == '{' && text.charAt(length-1) == '}') {
+      try {
+        JsonObject jsonObject = JsonUtils.parseJsonObject(text);
+        String source = jsonObject.getString("src");
+        String id = jsonObject.getString("id");
+        return new SzRecordId(source, id);
+      } catch (RuntimeException e) {
+        failure = e;
+      }
+    }
+
+    // try to parse as basic delimited string
+    if (length > 2) {
+      char sep = text.charAt(0);
+      int index = text.indexOf(sep, 1);
+      if (index < 0 || index == length - 1) {
+        if (failure != null) throw failure;
+        throw new IllegalArgumentException("Invalid record ID: " + text);
+      }
+      String prefix = text.substring(1, index);
+      String suffix = text.substring(index+1);
+      return new SzRecordId(prefix, suffix);
+
+    } else {
+      if (failure != null) throw failure;
+      throw new IllegalArgumentException("Invalid record ID: " + text);
+    }
   }
 }

--- a/src/main/java/com/senzing/api/server/services/EntityGraphServices.java
+++ b/src/main/java/com/senzing/api/server/services/EntityGraphServices.java
@@ -23,6 +23,10 @@ import static com.senzing.g2.engine.G2Engine.*;
 @Path("/")
 @Produces("application/json; charset=UTF-8")
 public class EntityGraphServices {
+  private static final int ENTITY_NOT_FOUND_CODE = 37;
+
+  private static final int RECORD_NOT_FOUND_CODE = 33;
+
   @GET
   @Path("entity-paths")
   public SzEntityPathResponse getEntityPath(
@@ -192,7 +196,7 @@ public class EntityGraphServices {
         }
 
         if (result != 0) {
-          throw newInternalServerErrorException(GET, uriInfo, engineApi);
+          throw newWebApplicationException(GET, uriInfo, engineApi);
         }
 
         // parse the raw data
@@ -244,8 +248,8 @@ public class EntityGraphServices {
         if (entitiesParam == null || entitiesParam.isEmpty()) {
           throw newBadRequestException(
               GET, uriInfo,
-              "Parameter missing or empty: \"entities\".  "
-                  + "One or more 'entities' entity identifiers are required.");
+              "Parameter missing or empty: 'e'.  "
+                  + "One or more 'e' entity identifiers are required.");
         }
 
         entities = parseEntityIdentifiers(
@@ -308,7 +312,7 @@ public class EntityGraphServices {
         }
 
         if (result != 0) {
-          throw newInternalServerErrorException(GET, uriInfo, engineApi);
+          throw newWebApplicationException(GET, uriInfo, engineApi);
         }
 
         // parse the raw data
@@ -360,4 +364,18 @@ public class EntityGraphServices {
     }
     return true;
   }
+
+  private static WebApplicationException newWebApplicationException(
+      SzHttpMethod  httpMethod,
+      UriInfo       uriInfo,
+      G2Engine      engineApi)
+  {
+    int errorCode = engineApi.getLastExceptionCode();
+    if (errorCode == ENTITY_NOT_FOUND_CODE
+        || errorCode == RECORD_NOT_FOUND_CODE) {
+      return newBadRequestException(GET, uriInfo, engineApi);
+    }
+    return newInternalServerErrorException(GET, uriInfo, engineApi);
+  }
+
 }

--- a/src/main/java/com/senzing/api/server/services/ServicesUtil.java
+++ b/src/main/java/com/senzing/api/server/services/ServicesUtil.java
@@ -141,6 +141,31 @@ public class ServicesUtil {
 
   /**
    * Creates an {@link BadRequestException} and builds a response
+   * with an {@link SzErrorResponse} using the specified {@link UriInfo}
+   * and the specified {@link G2Fallible} to get the last exception from.
+   *
+   * @param httpMethod The HTTP method for the request.
+   *
+   * @param uriInfo The {@link UriInfo} from the request.
+   *
+   * @param fallible The {@link G2Fallible} to get the last exception from.
+   *
+   * @return The {@link BadRequestException}
+   */
+  static BadRequestException newBadRequestException(
+      SzHttpMethod  httpMethod,
+      UriInfo       uriInfo,
+      G2Fallible    fallible)
+  {
+    Response.ResponseBuilder builder = Response.status(400);
+    builder.entity(
+        new SzErrorResponse(httpMethod, 400, uriInfo, fallible));
+    fallible.clearLastException();
+    return new BadRequestException(builder.build());
+  }
+
+  /**
+   * Creates an {@link BadRequestException} and builds a response
    * with an {@link SzErrorResponse} using the specified {@link UriInfo}.
    *
    * @param httpMethod The HTTP method for the request.


### PR DESCRIPTION
Modified EntityGraphServices to accept delimited encoding for SzRecordId.

Also modified EntityGraphServices so "entity-paths" and "entity-networks" return 400 errors when entities or records are not found.