### PR TITLE
Added entities and avoidEntities parameters to specify multiple entity identifiers in a single parameter as a comma-separated list or JSON array

### DIFF
--- a/src/main/java/com/senzing/api/model/SzEntityIdentifier.java
+++ b/src/main/java/com/senzing/api/model/SzEntityIdentifier.java
@@ -1,14 +1,5 @@
 package com.senzing.api.model;
 
-import com.senzing.util.JsonUtils;
-import org.glassfish.json.JsonUtil;
-
-import javax.ws.rs.PathParam;
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
-import java.util.ArrayList;
-import java.util.List;
-
 /**
  * A tagging interface for entity identifiers.
  */

--- a/src/main/java/com/senzing/api/model/SzEntityIdentifiers.java
+++ b/src/main/java/com/senzing/api/model/SzEntityIdentifiers.java
@@ -1,0 +1,319 @@
+package com.senzing.api.model;
+
+import com.senzing.util.JsonUtils;
+
+import javax.json.JsonArray;
+import javax.json.JsonNumber;
+import javax.json.JsonObject;
+import javax.json.JsonValue;
+import java.util.*;
+
+/**
+ * Used to represent a {@link List} of zero or more {@link SzEntityIdentifier}
+ * instances.
+ *
+ */
+public class SzEntityIdentifiers {
+  /**
+   * The {@link List} of {@link SzEntityIdentifier} instances.
+   */
+  private List<SzEntityIdentifier> identifiers;
+
+  /**
+   * Constructs with no {@link SzEntityIdentifier} instances.
+   */
+  public SzEntityIdentifiers() throws NullPointerException
+  {
+    this.identifiers = Collections.emptyList();
+  }
+
+  /**
+   * Constructs with a single {@link SzEntityIdentifier} instance.
+   *
+   * @param identifier The single non-null {@link SzEntityIdentifier} instance.
+   *
+   * @throws NullPointerException If the specified parameter is null.
+   */
+  public SzEntityIdentifiers(SzEntityIdentifier identifier)
+      throws NullPointerException
+  {
+    Objects.requireNonNull(identifier, "Identifier cannot be null.");
+    this.identifiers = Collections.singletonList(identifier);
+  }
+
+  /**
+   * Constructs with the specified {@link Collection} of {@link
+   * SzEntityIdentifier} instances.  The specified {@link Collection} will be
+   * copied.
+   *
+   * @param identifiers The non-null {@link Collection} of {@link
+   *                    SzEntityIdentifier} instances.
+   *
+   * @throws NullPointerException If the specified parameter is null.
+   */
+  public SzEntityIdentifiers(Collection<SzEntityIdentifier> identifiers)
+    throws NullPointerException
+  {
+    Objects.requireNonNull(identifiers, "Identifiers cannot be null.");
+    this.identifiers = Collections.unmodifiableList(
+        new ArrayList<>(identifiers));
+  }
+
+  /**
+   * Private constructor to use when the collection of {@link
+   * SzEntityIdentifier} instances may not need to be copied.
+   *
+   * @param identifiers The {@link List} of {@link SzEntityIdentifier}
+   *                    instances.
+   *
+   * @param copy <tt>true</tt> if the specified list should be copied or
+   *             used directly.
+   */
+  private SzEntityIdentifiers(List<SzEntityIdentifier>  identifiers,
+                              boolean                   copy)
+  {
+    if (copy) {
+      if (identifiers == null || identifiers.size() == 0) {
+        this.identifiers = Collections.emptyList();
+      } else {
+        this.identifiers = Collections.unmodifiableList(
+            new ArrayList<>(identifiers));
+      }
+    } else {
+      this.identifiers = identifiers;
+    }
+  }
+
+  /**
+   * Checks if all the {@link SzEntityIdentifier} instances contained are of the
+   * same type (e.g.: either {@link SzEntityId} or {@link SzRecordId}).
+   *
+   * @return <tt>true</tt> if the {@link SzEntityIdentifier} instances are
+   *         of the same type otherwise <tt>false</tt>.
+   */
+  public boolean isHomogeneous() {
+    Class<? extends SzEntityIdentifier> c = null;
+    for (SzEntityIdentifier i : this.identifiers) {
+      if (c == null) {
+        c = i.getClass();
+        continue;
+      }
+      if (c != i.getClass()) return false;
+    }
+    return true;
+  }
+
+  /**
+   * Checks if there are no entity identifiers specified for this instance.
+   *
+   * @return <tt>true</tt> if no entity identifiers are specified, otherwise
+   *         <tt>false</tt>.
+   */
+  public boolean isEmpty() {
+    return (this.identifiers == null || this.identifiers.size() == 0);
+  }
+
+  /**
+   * Returns the unmodifiable {@link List} of {@link SzEntityIdentifier}
+   * instances that were specified.
+   *
+   * @return The unmodifiable {@link List} of {@link SzEntityIdentifier}
+   *         instances that were specified.
+   */
+  public List<SzEntityIdentifier> getIdentifiers() {
+    return this.identifiers;
+  }
+
+  /**
+   * Parses the specified text as a {@link List} of homogeneous
+   * {@link SzEntityIdentifier} instances.
+   *
+   * @param text The text to parse.
+   *
+   * @return The {@link SzEntityIdentifiers} instance representing the {@link
+   *         List} of {@link SzEntityIdentifier} instances.
+   */
+  public static SzEntityIdentifiers valueOf(String text) {
+    text = text.trim();
+    int               length  = text.length();
+    char              first   = text.charAt(0);
+    char              last    = text.charAt(length-1);
+
+    // check if no identifiers
+    if (length == 0) {
+      // no identifiers
+      return new SzEntityIdentifiers();
+    }
+
+    // check if it looks like a JSON array
+    if (first == '[' && last == ']') {
+      try {
+        return parseAsJsonArray(text);
+
+      } catch (RuntimeException e) {
+        // ignore
+      }
+    }
+
+    // check if we have yet to find the identifiers
+    if (first == '{' && last == '}') {
+      try {
+        // it appears we have a JSON object for a single entity identifier
+        JsonObject jsonObject = JsonUtils.parseJsonObject(text);
+        SzRecordId recordId = SzRecordId.parse(jsonObject);
+        return new SzEntityIdentifiers(recordId);
+
+      } catch (RuntimeException e) {
+        // ignore
+      }
+    }
+
+    // check if we have a comma-separated list of entity IDs
+    if (text.matches("(-?[\\d]+\\s*,\\s*)+-?[\\d]+")) {
+      String[] tokens = text.split("\\s*,\\s*");
+      List<SzEntityIdentifier> identifiers = new ArrayList<>(tokens.length);
+      for (String token : tokens) {
+        token = token.trim();
+        identifiers.add(SzEntityId.valueOf(token));
+      }
+      identifiers = Collections.unmodifiableList(identifiers);
+      return new SzEntityIdentifiers(identifiers, false);
+    }
+
+    // try to convert it to a JSON array
+    if (first != '[' && last != ']') {
+      try {
+        return parseAsJsonArray("[" + text + "]");
+
+      } catch (RuntimeException e) {
+        // ignore
+      }
+    }
+
+    // try to parse as delimited records -- this assumes data source codes
+    // and record IDs do not contain commas
+    try {
+      return parseAsDelimitedTokens(text);
+
+    } catch (RuntimeException e) {
+      // ignore
+    }
+
+    // if we get here then check for a failure
+    throw new IllegalArgumentException(
+        "Unable to interpret the text as a list of entity identifiers: "
+        + text);
+  }
+
+  /**
+   * Parses the specified text as a JSON array.
+   *
+   * @param text The text to parse
+   * @return The {@link SzEntityIdentifiers} that was parsed.
+   */
+  private static SzEntityIdentifiers parseAsJsonArray(String text) {
+    // it appears we have a JSON array of entity identifiers
+    JsonArray jsonArray = JsonUtils.parseJsonArray(text);
+    List<SzEntityIdentifier> identifiers
+        = new ArrayList<>(jsonArray.size());
+    JsonValue.ValueType valueType = null;
+    for (JsonValue value : jsonArray) {
+      JsonValue.ValueType vt = value.getValueType();
+      SzEntityIdentifier identifier = null;
+      switch (vt) {
+        case NUMBER:
+          identifier = new SzEntityId(((JsonNumber) value).longValue());
+          break;
+
+        case OBJECT:
+          identifier = SzRecordId.parse((JsonObject) value);
+          break;
+
+        default:
+          throw new IllegalArgumentException(
+              "Unexpected element in entity identifier array: valueType=[ "
+                  + valueType + " ], value=[ " + value + " ]");
+      }
+      identifiers.add(identifier);
+    }
+
+    // make the list unmodifiable
+    return new SzEntityIdentifiers(
+        Collections.unmodifiableList(identifiers), false);
+  }
+
+  /**
+   * Parses the specified text as comma-delimited tokens to build an instance
+   * of {@link SzEntityIdentifiers}.
+   *
+   * @param text The text to be parsed.
+   * @return The {@link SzEntityIdentifiers} that was parsed.
+   */
+  private static SzEntityIdentifiers parseAsDelimitedTokens(String text) {
+    String[]      rawTokens = text.split("\\s*,\\s*");
+    List<String>  tokens    = new ArrayList<>(rawTokens.length);
+
+    String jsonStart = null;
+    for (String rawToken : rawTokens) {
+      String tok = rawToken.trim();
+      // check if we are starting a JSON token
+      if (jsonStart == null && tok.startsWith("{") && tok.endsWith("\""))
+      {
+        // looks like JSON
+        jsonStart = rawToken;
+        continue;
+      }
+
+      // check if we are completing a JSON token
+      if (jsonStart != null && tok.startsWith("\"") && tok.endsWith("}")) {
+        try {
+          String jsonText = jsonStart + "," + rawToken;
+          JsonObject obj = JsonUtils.parseJsonObject(jsonText);
+
+          tokens.add(jsonText);
+
+        } catch (Exception e) {
+          // not JSON
+          tokens.add(jsonStart);
+          tokens.add(rawToken);
+
+        } finally {
+          jsonStart = null;
+        }
+        continue;
+      }
+
+      // otherwise just take the raw token as-is
+      if (jsonStart != null) tokens.add(jsonStart);
+      tokens.add(rawToken);
+      jsonStart = null;
+    }
+
+    List<SzEntityIdentifier> identifiers = new ArrayList<>(tokens.size());
+    for (String token : tokens) {
+      token = token.trim();
+      identifiers.add(SzEntityIdentifier.valueOf(token));
+    }
+    identifiers = Collections.unmodifiableList(identifiers);
+    return new SzEntityIdentifiers(identifiers, false);
+  }
+
+  /**
+   * Test main function.
+   */
+  public static void main(String[] args) {
+    for (String arg : args) {
+      System.out.println();
+      System.out.println("- - - - - - - - - - - - - - - - - - - - - ");
+      System.out.println("PARSING: " + arg);
+      try {
+        SzEntityIdentifiers identifiers = SzEntityIdentifiers.valueOf(arg);
+        System.out.println(identifiers.getIdentifiers());
+
+      } catch (Exception e) {
+        e.printStackTrace(System.out);
+      }
+
+    }
+  }
+}

--- a/src/main/java/com/senzing/api/model/SzRecordId.java
+++ b/src/main/java/com/senzing/api/model/SzRecordId.java
@@ -33,7 +33,6 @@ public class SzRecordId implements SzEntityIdentifier {
    * Constructs with the specified data source code and record ID.
    *
    * @param dataSourceCode The data source code.
-   *
    * @param recordId The record ID identifying the record.
    */
   public SzRecordId(String dataSourceCode, String recordId) {
@@ -112,7 +111,6 @@ public class SzRecordId implements SzEntityIdentifier {
    * </ul>
    *
    * @param text The JSON text to parse.
-   *
    * @return The {@link SzRecordId} that was created.
    */
   public static SzRecordId valueOf(String text) {
@@ -121,7 +119,7 @@ public class SzRecordId implements SzEntityIdentifier {
     int length = text.length();
 
     // first try to parse as JSON
-    if (length > 2 && text.charAt(0) == '{' && text.charAt(length-1) == '}') {
+    if (length > 2 && text.charAt(0) == '{' && text.charAt(length - 1) == '}') {
       try {
         JsonObject jsonObject = JsonUtils.parseJsonObject(text);
         String source = jsonObject.getString("src");
@@ -141,12 +139,39 @@ public class SzRecordId implements SzEntityIdentifier {
         throw new IllegalArgumentException("Invalid record ID: " + text);
       }
       String prefix = text.substring(1, index);
-      String suffix = text.substring(index+1);
+      String suffix = text.substring(index + 1);
       return new SzRecordId(prefix, suffix);
 
     } else {
       if (failure != null) throw failure;
       throw new IllegalArgumentException("Invalid record ID: " + text);
     }
+  }
+
+  /**
+   * Parses the specified {@link JsonObject} as a record ID.  This expects
+   * (and prefers) the <tt>"src"</tt> and <tt>"id"</tt> properties but will
+   * alternatively accept the <tt>"dataSourceCode"</tt> and <tt>"recordId"</tt>
+   * properties.
+   *
+   * @param jsonObject The {@link JsonObject} to parse.
+   *
+   * @return The {@link SzRecordId} that was created.
+   */
+  public static SzRecordId parse(JsonObject jsonObject) {
+    String src = JsonUtils.getString(jsonObject, "src");
+    if (src == null) {
+      src = JsonUtils.getString(jsonObject, "dataSourceCode");
+    }
+    String id = JsonUtils.getString(jsonObject, "id");
+    if (id == null) {
+      id = JsonUtils.getString(jsonObject, "recordId");
+    }
+    if (src == null || id == null) {
+      throw new IllegalArgumentException(
+          "The specified JsonObject does not have the required fields.  src=[ "
+          + src + " ], id=[ " + id + " ], jsonObject=[ " + jsonObject + " ]");
+    }
+    return new SzRecordId(src, id);
   }
 }

--- a/src/main/java/com/senzing/api/server/services/ServicesUtil.java
+++ b/src/main/java/com/senzing/api/server/services/ServicesUtil.java
@@ -14,8 +14,7 @@ import javax.ws.rs.core.UriInfo;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 
 /**
  * Utility functions for services.
@@ -272,21 +271,21 @@ public class ServicesUtil {
   }
 
   /**
-   * Encodes a {@link List} of {@link SzEntityIdentifier} instances as a
+   * Encodes a {@link Collection} of {@link SzEntityIdentifier} instances as a
    * JSON array string in the native Senzing format format for entity
    * identifiers.
    *
-   * @param list The list of entity identifiers.
+   * @param ids The {@link Collection} of entity identifiers.
    *
    * @return The JSON array string for the identifiers.
    */
-  static String nativeJsonEncodeEntityIds(List<SzEntityIdentifier> list) {
-    if (list == null) {
+  static String nativeJsonEncodeEntityIds(Collection<SzEntityIdentifier> ids) {
+    if (ids == null) {
       return null;
     }
     String propName = "ENTITIES";
     JsonArrayBuilder jab = Json.createArrayBuilder();
-    for (SzEntityIdentifier id : list) {
+    for (SzEntityIdentifier id : ids) {
       if (id instanceof SzEntityId) {
         JsonObjectBuilder job = Json.createObjectBuilder();
         job.add("ENTITY_ID", ((SzEntityId) id).getValue());
@@ -306,19 +305,19 @@ public class ServicesUtil {
   }
 
   /**
-   * Encodes a {@link List} of {@link SzEntityIdentifier} instances as a
+   * Encodes a {@link Collection} of {@link SzEntityIdentifier} instances as a
    * JSON array string (without the leading and terminating brackets)
    * with each of the individual items in the list being URL encoded.
    *
-   * @param list The list of entity identifiers.
+   * @param ids The {@link Collection} of entity identifiers.
    *
    * @return The URL-encoded JSON array string for the identifiers.
    */
-  static String urlEncodeEntityIds(List<SzEntityIdentifier> list)
+  static String urlEncodeEntityIds(Collection<SzEntityIdentifier> ids)
   {
     StringBuilder sb = new StringBuilder();
     String prefix = "";
-    for (SzEntityIdentifier id : list) {
+    for (SzEntityIdentifier id : ids) {
       sb.append(prefix);
       prefix = ",";
       if (id instanceof SzEntityId) {
@@ -383,7 +382,7 @@ public class ServicesUtil {
 
   /**
    * Combines multiple {@link String} entity identifier parameters into a
-   * JSON array and parses it as JSON to produce a {@link List} of {@link
+   * JSON array and parses it as JSON to produce a {@link Set} of {@link
    * SzEntityIdentifier} instances.
    *
    * @param params The paramter values to parse.
@@ -394,17 +393,23 @@ public class ServicesUtil {
    *
    * @param uriInfo The {@link UriInfo} from the request.
    *
-   * @return The {@link List} of {@link SzEntityIdentifier} instances that was
+   * @return The {@link Set} of {@link SzEntityIdentifier} instances that was
    *         parsed from the specified parameters.
    */
-  static List<SzEntityIdentifier> parseEntityIdentifiers(
+  static Set<SzEntityIdentifier> parseEntityIdentifiers(
       List<String>  params,
       String        paramName,
       SzHttpMethod  httpMethod,
       UriInfo       uriInfo)
   {
-    List<SzEntityIdentifier> result = new ArrayList<>(params.size());
+    Set<SzEntityIdentifier> result = new LinkedHashSet<>();
 
+    // check if the params is null or missing
+    if (params == null || params.size() == 0) {
+      return result;
+    }
+
+    // iterate over the params
     for (String param : params) {
       try {
         SzEntityIdentifier id = SzEntityIdentifier.valueOf(param);


### PR DESCRIPTION
Added the following parameters:

- entity-paths: "avoidEntities" in addition to "x" parameter -- if both are specified then entity identifiers are merged.

- entity-networks: "entities" in addition to "e" parameter -- if both are specified then entity identifiers are merged.

In both cases all entity identifiers must be SzRecordId or SzEntityId -- you cannot mix and match.
