### PR TITLE
Fixed NullPointerException and error reporting of it for /entity-networks

### DIFF
--- a/src/main/java/com/senzing/api/server/services/EntityGraphServices.java
+++ b/src/main/java/com/senzing/api/server/services/EntityGraphServices.java
@@ -259,7 +259,7 @@ public class EntityGraphServices {
       // check for consistent entity IDs
       try {
         if ((entitiesParam == null || entitiesParam.isEmpty())
-            && (entityList == null) || entityList.isEmpty())
+            && ((entityList == null) || entityList.isEmpty()))
         {
           throw newBadRequestException(
               GET, uriInfo,
@@ -307,6 +307,7 @@ public class EntityGraphServices {
       } catch (WebApplicationException e) {
         throw e;
       } catch (Exception e) {
+        e.printStackTrace();
         throw newBadRequestException(GET, uriInfo, e.getMessage());
       }
 

--- a/src/main/java/com/senzing/api/server/services/ServicesUtil.java
+++ b/src/main/java/com/senzing/api/server/services/ServicesUtil.java
@@ -189,6 +189,31 @@ public class ServicesUtil {
   }
 
   /**
+   * Creates an {@link InternalServerErrorException} and builds a response
+   * with an {@link SzErrorResponse} using the specified {@link UriInfo}
+   * and the specified exception.
+   *
+   * @param httpMethod The HTTP method for the request.
+   *
+   * @param uriInfo The {@link UriInfo} from the request.
+   *
+   * @param exception The exception that caused the error.
+   *
+   * @return The {@link InternalServerErrorException}
+   */
+  static BadRequestException newBadRequestException(
+      SzHttpMethod  httpMethod,
+      UriInfo       uriInfo,
+      Exception     exception)
+  {
+    Response.ResponseBuilder builder = Response.status(400);
+    builder.entity(
+        new SzErrorResponse(httpMethod, 400, uriInfo, exception));
+    return new BadRequestException(builder.build());
+  }
+
+
+  /**
    * URL encodes the specified text using UTF-8 encoding.
    *
    * @param text The text to encode.


### PR DESCRIPTION
Found and fixed error reporting issue that made it possible to see the source of the NullPointerException.

Then found and fixed the NullPointerException (specifically caused by order-of-operation issue by misplaced parentheses).
