### PR TITLE
Added SzMatchedRecord which extends SzEntityRecord to resolve issue 51

### DIFF
--- a/src/main/java/com/senzing/api/model/SzBaseRelatedEntity.java
+++ b/src/main/java/com/senzing/api/model/SzBaseRelatedEntity.java
@@ -303,7 +303,7 @@ public abstract class SzBaseRelatedEntity extends SzResolvedEntity {
             case STRING:
               // check for empty string
               if (jsonObject.getString("MATCH_SCORE").trim().length() == 0) {
-                // empty string is the same as zero (0)
+                // empty string is the same as null
                 return null;
               } else {
                 // if not an empty string then parse as an integer

--- a/src/main/java/com/senzing/api/model/SzEntityRecord.java
+++ b/src/main/java/com/senzing/api/model/SzEntityRecord.java
@@ -461,8 +461,11 @@ public class SzEntityRecord {
 
   @Override
   public String toString() {
-    return "SzEntityRecord{" +
-        "dataSource='" + dataSource + '\'' +
+    return "SzEntityRecord{" + this.fieldsToString() + "}";
+  }
+
+  protected String fieldsToString() {
+    return "dataSource='" + dataSource + '\'' +
         ", recordId='" + recordId + '\'' +
         ", addressData=" + addressData +
         ", attributeData=" + attributeData +
@@ -471,7 +474,6 @@ public class SzEntityRecord {
         ", phoneData=" + phoneData +
         ", relationshipData=" + relationshipData +
         ", otherData=" + otherData +
-        ", originalSourceData=" + originalSourceData +
-        '}';
+        ", originalSourceData=" + originalSourceData;
   }
 }

--- a/src/main/java/com/senzing/api/model/SzMatchedRecord.java
+++ b/src/main/java/com/senzing/api/model/SzMatchedRecord.java
@@ -1,0 +1,243 @@
+package com.senzing.api.model;
+
+import com.senzing.util.JsonUtils;
+
+import javax.json.JsonArray;
+import javax.json.JsonObject;
+import java.util.*;
+
+/**
+ * Describes an entity record that has matched another record in a resolved
+ * entity.
+ */
+public class SzMatchedRecord extends SzEntityRecord {
+  /**
+   * The match level.
+   */
+  private Integer matchLevel;
+
+  /**
+   * The match score.
+   */
+  private Integer matchScore;
+
+  /**
+   * The match key for the relationship.
+   */
+  private String matchKey;
+
+  /**
+   * The resolution rule code.
+   */
+  private String resolutionRuleCode;
+
+  /**
+   * The ref score.
+   */
+  private Integer refScore;
+
+  /**
+   * Default constructor.
+   */
+  public SzMatchedRecord() {
+    super();
+    this.matchKey           = null;
+    this.resolutionRuleCode = null;
+    this.matchLevel         = null;
+    this.matchScore         = null;
+    this.refScore           = null;
+  }
+
+  /**
+   * Gets the match level for how this record matched against the first record
+   * in the resolved entity.
+   *
+   * @return The match level for how this record matched against the first record
+   *         in the resolved entity.
+   */
+  public Integer getMatchLevel() {
+    return matchLevel;
+  }
+
+  /**
+   * Sets the match level for how this record matched against the first record
+   * in the resolved entity.
+   *
+   * @param matchLevel The match level for how this record matched against the
+   *                   first record in the resolved entity.
+   */
+  public void setMatchLevel(Integer matchLevel) {
+    this.matchLevel = matchLevel;
+  }
+
+  /**
+   * Gets the match score for how this record matched against the first record
+   * in the resolved entity.
+   *
+   * @return The match score for how this record matched against the first
+   *         record in the resolved entity.
+   */
+  public Integer getMatchScore() {
+    return matchScore;
+  }
+
+  /**
+   * Sets the match score for how this record matched against the first record
+   * in the resolved entity.
+   *
+   * @param matchScore The match score for how this record matched against the
+   *                   first record in the resolved entity.
+   */
+  public void setMatchScore(Integer matchScore) {
+    this.matchScore = matchScore;
+  }
+
+  /**
+   * Gets the match key for how this record matched against the first record
+   * in the resolved entity.
+   *
+   * @return The match key for how this record matched against the first record
+   *         in the resolved entity.
+   */
+  public String getMatchKey() {
+    return matchKey;
+  }
+
+  /**
+   * Sets the match key for how this record matched against the first record
+   * in the resolved entity.
+   *
+   * @param matchKey The match key for how this record matched against the
+   *                 first record in the resolved entity.
+   */
+  public void setMatchKey(String matchKey) {
+    this.matchKey = matchKey;
+  }
+
+  /**
+   * Gets the resolution rule code for how this record matched against the
+   * first record in the resolved entity.
+   *
+   * @return The resolution rule code for how this record matched against the
+   *         first record in the resolved entity.
+   */
+  public String getResolutionRuleCode() {
+    return resolutionRuleCode;
+  }
+
+  /**
+   * Sets the resolution rule code for how this record matched against the
+   * first record in the resolved entity.
+   *
+   * @param resolutionRuleCode The resolution rule code for how this record
+   *                           matched against the first record in the
+   *                           resolved entity.
+   */
+  public void setResolutionRuleCode(String resolutionRuleCode) {
+    this.resolutionRuleCode = resolutionRuleCode;
+  }
+
+  /**
+   * Gets the ref score for how this record matched against the
+   * first record in the resolved entity.
+   *
+   * @return The ref score for how this record matched against the
+   *         first record in the resolved entity.
+   */
+  public Integer getRefScore() {
+    return refScore;
+  }
+
+  /**
+   * Sets the ref score for how this record matched against the first record
+   * in the resolved entity.
+   *
+   * @param refScore The ref score for how this record matched against the
+   *                 first record in the resolved entity.
+   */
+  public void setRefScore(Integer refScore) {
+    this.refScore = refScore;
+  }
+
+  /**
+   * Parses the native JSON to construct/populate a {@link List}
+   * of {@link SzMatchedRecord} instances.
+   *
+   * @param list The {@link List} to populate or <tt>null</tt> if a new {@link
+   *             List} should be created.
+   * @param jsonArray The {@link JsonArray} describing the native JSON array.
+   *
+   * @return The specified (or constructed) {@link List} of {@link
+   *         SzMatchedRecord} instances.
+   */
+  public static List<SzMatchedRecord> parseMatchedRecordList(
+      List<SzMatchedRecord>  list,
+      JsonArray             jsonArray)
+  {
+    for (JsonObject jsonObject : jsonArray.getValuesAs(JsonObject.class)) {
+      if (list == null) {
+        list = new ArrayList<SzMatchedRecord>(jsonArray.size());
+      }
+      list.add(parseMatchedRecord(null, jsonObject));
+    }
+    if (list != null) {
+      list = Collections.unmodifiableList(list);
+    } else {
+      list = Collections.emptyList();
+    }
+    return list;
+  }
+
+  /**
+   * Parses the native API JSON to build an populate or create an instance of
+   * {@link SzMatchedRecord}.
+   *
+   * @param record The {@link SzMatchedRecord} to populate or <tt>null</tt> if
+   *               a new instance should be created.
+   *
+   * @param jsonObject The {@link JsonObject} describing the record using the
+   *                   native API JSON format.
+   *
+   * @return The populated (or created) instance of {@link SzMatchedRecord}
+   */
+  public static SzMatchedRecord parseMatchedRecord(SzMatchedRecord record,
+                                                   JsonObject     jsonObject)
+  {
+    if (record == null) record = new SzMatchedRecord();
+
+    // populate from the base class
+    parseEntityRecord(record, jsonObject);
+
+    // now get the match fields
+    Optional<Integer> matchScore = SzBaseRelatedEntity.readMatchScore(jsonObject);
+
+    String  matchKey    = JsonUtils.getString(jsonObject, "MATCH_KEY");
+    Integer matchLevel  = JsonUtils.getInteger(jsonObject, "MATCH_LEVEL");
+    Integer refScore    = JsonUtils.getInteger(jsonObject, "REF_SCORE");
+    String  ruleCode    = JsonUtils.getString(jsonObject,"ERRULE_CODE");
+
+    record.setMatchScore(matchScore.orElse(null));
+    record.setMatchKey(matchKey);
+    record.setMatchLevel(matchLevel);
+    record.setRefScore(refScore);
+    record.setResolutionRuleCode(ruleCode);
+
+    return record;
+  }
+
+  @Override
+  public String toString() {
+    return "SzMatchedRecord{" + this.fieldsToString() + "}";
+  }
+
+  @Override
+  protected String fieldsToString() {
+    return super.fieldsToString() +
+        ", matchLevel=" + matchLevel +
+        ", matchScore=" + matchScore +
+        ", matchKey='" + matchKey + '\'' +
+        ", resolutionRuleCode='" + resolutionRuleCode + '\'' +
+        ", refScore=" + refScore;
+  }
+
+}

--- a/src/main/java/com/senzing/api/model/SzResolvedEntity.java
+++ b/src/main/java/com/senzing/api/model/SzResolvedEntity.java
@@ -80,10 +80,10 @@ public class SzResolvedEntity {
   private Map<String, List<SzEntityFeature>> unmodifiableFeatures;
 
   /**
-   * The {@link List} of {@link SzEntityRecord} instances for the
+   * The {@link List} of {@link SzMatchedRecord} instances for the
    * records in the entity.
    */
-  private List<SzEntityRecord> records;
+  private List<SzMatchedRecord> records;
 
   /**
    * Whether or not this entity is partially populated.
@@ -174,22 +174,22 @@ public class SzResolvedEntity {
   }
 
   /**
-   * Returns the list of {@link SzEntityRecord} instances describing the records
+   * Returns the list of {@link SzMatchedRecord} instances describing the records
    * for the entity.
    *
-   * @return The list of {@link SzEntityRecord} instances describing the records
+   * @return The list of {@link SzMatchedRecord} instances describing the records
    *         for the entity.
    */
-  public List<SzEntityRecord> getRecords() {
+  public List<SzMatchedRecord> getRecords() {
     return Collections.unmodifiableList(this.records);
   }
 
   /**
-   * Sets the list {@linkplain SzEntityRecord records} for the entity.
+   * Sets the list {@linkplain SzMatchedRecord records} for the entity.
    *
-   * @param records The list {@linkplain SzEntityRecord records} for the entity.
+   * @param records The list {@linkplain SzMatchedRecord records} for the entity.
    */
-  public void setRecords(List<SzEntityRecord> records) {
+  public void setRecords(List<SzMatchedRecord> records) {
     this.records.clear();
     if (records != null) {
       this.records.addAll(records);
@@ -197,12 +197,12 @@ public class SzResolvedEntity {
   }
 
   /**
-   * Adds the specified {@link SzEntityRecord} to the list of {@linkplain
-   * SzEntityRecord records}.
+   * Adds the specified {@link SzMatchedRecord} to the list of {@linkplain
+   * SzMatchedRecord records}.
    *
-   * @param record The {@link SzEntityRecord} to add to the record list.
+   * @param record The {@link SzMatchedRecord} to add to the record list.
    */
-  public void addRecord(SzEntityRecord record)
+  public void addRecord(SzMatchedRecord record)
   {
     this.records.add(record);
   }
@@ -705,12 +705,12 @@ public class SzResolvedEntity {
     }
 
     // get the records
-    List<SzEntityRecord> recordList = null;
+    List<SzMatchedRecord> recordList = null;
     List<SzRecordSummary> summaries = null;
 
     if (jsonObject.containsKey("RECORDS")) {
       JsonArray records = jsonObject.getJsonArray("RECORDS");
-      recordList = SzEntityRecord.parseEntityRecordList(null, records);
+      recordList = SzMatchedRecord.parseMatchedRecordList(null, records);
       summaries = summarizeRecords(recordList);
 
     } else if (jsonObject.containsKey("RECORD_SUMMARY")) {
@@ -731,7 +731,7 @@ public class SzResolvedEntity {
   }
 
   /**
-   * Summarizes the specified {@link List} of {@linkplain SzEntityRecord
+   * Summarizes the specified {@link List} of {@linkplain SzMatchedRecord
    * records} and produces a {@link List} of {@link SzRecordSummary} instances.
    *
    * @param records The records to be summarized.
@@ -739,7 +739,7 @@ public class SzResolvedEntity {
    *         the summaries.
    */
   public static List<SzRecordSummary> summarizeRecords(
-      List<SzEntityRecord>  records)
+      List<SzMatchedRecord>  records)
   {
     // check if we have no records
     if (records.size() == 0) return Collections.emptyList();

--- a/src/main/java/com/senzing/api/server/services/EntityDataServices.java
+++ b/src/main/java/com/senzing/api/server/services/EntityDataServices.java
@@ -308,7 +308,7 @@ public class EntityDataServices {
         for (SzEntityData edata : dataMap.values()) {
           SzResolvedEntity resolvedEntity = edata.getResolvedEntity();
           // check if this entity is the one that was requested by record ID
-          for (SzEntityRecord record : resolvedEntity.getRecords()) {
+          for (SzMatchedRecord record : resolvedEntity.getRecords()) {
             if (record.getDataSource().equalsIgnoreCase(dataSource)
                 && record.getRecordId().equals(recordId)) {
               // found the entity ID for the record ID
@@ -633,7 +633,7 @@ public class EntityDataServices {
       Map<String, List<SzEntityFeature>> features
           = related.getFeatures();
 
-      List<SzEntityRecord> records = related.getRecords();
+      List<SzMatchedRecord> records = related.getRecords();
 
       // summarize the records
       List<SzRecordSummary> summaries


### PR DESCRIPTION
This resolves Issue #51 .

This is solved by creating SzMatchedRecord which extends SzEntityRecord to add the needed fields.

This is required because the "GET /data-sources/{dataSourceCode}/records/{recordId}" end-point uses "getRecord()" and does not get these fields returned (nor do they make sense for that endpoint). So SzEntityRecord still exists to service that endpoint.

SzResolvedEntity is modified to maintain an array of SzMatchedRecord instead which adds the needed fields for the "GET /entities/{entityId}" endpoint as well as others.

EntityDataServices required update as well to work with lists of SzMatchedRecord.  

Finally, I factored out the functionality for extracting the MATCH_SCORE from native Senzing JSON in SzBaseRelatedEntity into a public static function on the same class for now for reuse -- this is used in SzMatchedRecord as well for now to eliminate duplication of this code in two places.