### PR TITLE
Error handling for configMgr.initV2() in getConfigType() + misc other improvements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.senzing</groupId>
   <artifactId>senzing-api-server</artifactId>
   <packaging>jar</packaging>
-  <version>1.7.2</version>
+  <version>1.7.3</version>
   <name>senzing-api-server</name>
   <url>http://maven.apache.org</url>
   <dependencies>

--- a/src/main/java/com/senzing/api/server/G2EngineRetryHandler.java
+++ b/src/main/java/com/senzing/api/server/G2EngineRetryHandler.java
@@ -30,6 +30,26 @@ class G2EngineRetryHandler implements InvocationHandler {
    */
   private static Set<Method> UNSUPPORTED_METHODS;
 
+  /**
+   * Utility method to get an optional method that may not exist on the version
+   * of g2.jar that we are building with.
+   */
+  private static void addMethodIfExists(Set<Method> set,
+                                        String      name,
+                                        Class...    argTypes)
+  {
+    Method method = null;
+    try {
+      method = G2Engine.class.getMethod(name, argTypes);
+    } catch (NoSuchMethodException ignore) {
+      return;
+    }
+    set.add(method);
+  }
+
+  /**
+   * static initializer
+   */
   static {
     Class<G2Engine> cls = G2Engine.class;
     Set<Method> retrySet        = new LinkedHashSet<>();
@@ -48,6 +68,27 @@ class G2EngineRetryHandler implements InvocationHandler {
           String.class, String.class, long.class, boolean.class));
       unsupportedSet.add(cls.getMethod("reinitV2", long.class));
       unsupportedSet.add(cls.getMethod("destroy"));
+
+      // handle unsupported methods that may not be in the version of g2.jar
+      // that is installed in the build/runtime environment
+      addMethodIfExists(unsupportedSet,"addRecordWithInfo",
+                        String.class, String.class, String.class,
+                        String.class, int.class, StringBuffer.class);
+      addMethodIfExists(unsupportedSet,"replaceRecordWithInfo",
+                        String.class, String.class, String.class,
+                        String.class, int.class, StringBuffer.class);
+      addMethodIfExists(unsupportedSet,"deleteRecordWithInfo",
+                        String.class, String.class, String.class,
+                        int.class, StringBuffer.class);
+      addMethodIfExists(unsupportedSet,"reevaluateEntityWithInfo",
+                        long.class, int.class, StringBuffer.class);
+      addMethodIfExists(unsupportedSet,"reevaluateRecordWithInfo",
+                        String.class, String.class,
+                        int.class, StringBuffer.class);
+      addMethodIfExists(unsupportedSet,"processRedoRecordWithInfo",
+                        int.class, StringBuffer.class, StringBuffer.class);
+      addMethodIfExists(unsupportedSet,"processWithInfo",
+                        String.class, int.class, StringBuffer.class);
 
       directSet.add(cls.getMethod("primeEngine"));
       directSet.add(cls.getMethod("purgeRepository"));

--- a/src/main/java/com/senzing/api/server/SzApiServer.java
+++ b/src/main/java/com/senzing/api/server/SzApiServer.java
@@ -992,11 +992,9 @@ public class SzApiServer implements SzApiProvider {
             = SzApiProvider.Factory.installProvider(SzApiServer.INSTANCE);
 
       } catch (RuntimeException e) {
-        e.printStackTrace();
         throw e;
 
       } catch (Exception e) {
-        e.printStackTrace();
         throw new RuntimeException(e);
       }
     }
@@ -1512,7 +1510,21 @@ public class SzApiServer implements SzApiProvider {
 
     boolean configInRepo = false;
     G2ConfigMgr configMgr = new G2ConfigMgrJNI();
-    configMgr.initV2(SzApiServer.class.getSimpleName(), initJsonText, false);
+    int returnCode = configMgr.initV2(SzApiServer.class.getSimpleName(), initJsonText, false);
+    if (returnCode != 0) {
+      String msg = multilineFormat(
+          "Failed to initialize with specified initialization parameters.",
+          "",
+          formatError("G2ConfigMgr.initV2", configMgr)
+          + "Initialization parameters:",
+          "",
+          (initJsonText.length() > 80
+            ? initJsonText.substring(0, 64) + " ... [truncated]"
+            : initJsonText),
+          "");
+
+      throw new RuntimeException(msg);
+    }
     try {
       Result<Long> defaultConfigResult = new Result<>();
       configMgr.getDefaultConfigID(defaultConfigResult);


### PR DESCRIPTION
- Added error handling for bad result from G2ConfigMgr.initV2() in the getConfigType() function
- Added additional methods to the explicitly unsupported list to avoid warnings on startup if building with version 1.11.x pre-release of g2.jar
- Increased version number in pom.xml to 1.7.3