### PR TITLE
Fixed auto tests on 1.11.1 and reduced repetitive output when command line args are invalid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.4] - 2019-09-13
+
+### Changes in 1.7.4
+
+- Less repetitive/verbose output when invalid command line options are provided.
+- Fixes auto tests when building with 1.11.1.x versions of native Senzing libs.
+
+## [1.7.3] - 2019-08-30
+
+### Changes in 1.7.3
+
+- Fixed bug where the initialization of the configuration manager
+(`G2ConfigMgr.initV2()`) was not checked for success or failure.  Now the 
+API server ensures that initialization succeeded before proceeding further.
+- Removed warnings that could occur if building with version 1.11.x of g2.jar
+
 ## [1.7.2] - 2019-08-19
 
 ### Added in 1.7.2

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.senzing</groupId>
   <artifactId>senzing-api-server</artifactId>
   <packaging>jar</packaging>
-  <version>1.7.3</version>
+  <version>1.7.4</version>
   <name>senzing-api-server</name>
   <url>http://maven.apache.org</url>
   <dependencies>

--- a/src/main/java/com/senzing/cmdline/CommandLineUtilities.java
+++ b/src/main/java/com/senzing/cmdline/CommandLineUtilities.java
@@ -4,6 +4,12 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.*;
 
+import static com.senzing.util.LoggingUtilities.*;
+
+/**
+ * Utility functions for parsing command line arguments.
+ *
+ */
 public class CommandLineUtilities {
   /**
    * Private default constructor.
@@ -27,7 +33,7 @@ public class CommandLineUtilities {
       System.err.println();
       System.err.println(msg);
 
-      throw new IllegalArgumentException(msg);
+      setLastLoggedAndThrow(new IllegalArgumentException(msg));
     }
   }
 
@@ -82,7 +88,7 @@ public class CommandLineUtilities {
       System.err.println();
       System.err.println(msg);
 
-      throw new IllegalArgumentException(msg);
+      setLastLoggedAndThrow(new IllegalArgumentException(msg));
     }
 
     for (T opt : optionKeys) {
@@ -94,7 +100,7 @@ public class CommandLineUtilities {
         System.err.println();
         System.err.println(msg);
 
-        throw new IllegalArgumentException(msg);
+        setLastLoggedAndThrow(new IllegalArgumentException(msg));
       }
     }
 
@@ -205,8 +211,7 @@ public class CommandLineUtilities {
         pw.flush();
         System.err.println();
         System.err.println(msg);
-
-        throw new IllegalArgumentException(msg);
+        setLastLoggedException(new IllegalArgumentException(msg));
       }
     }
 
@@ -226,7 +231,7 @@ public class CommandLineUtilities {
             System.err.println();
             System.err.println(msg);
 
-            throw new IllegalArgumentException(msg);
+            setLastLoggedAndThrow(new IllegalArgumentException(msg));
           }
         }
       }
@@ -276,8 +281,8 @@ public class CommandLineUtilities {
             }
           }
         }
-        throw new IllegalArgumentException(
-            "Missing dependencies for " + option.getCommandLineFlag());
+        setLastLoggedAndThrow(new IllegalArgumentException(
+            "Missing dependencies for " + option.getCommandLineFlag()));
       }
     }
   }
@@ -307,8 +312,8 @@ public class CommandLineUtilities {
         System.err.println();
         System.err.println("Unrecognized option: " + args[index]);
 
-        throw new IllegalArgumentException(
-            "Unrecognized command line option: " + args[index]);
+        setLastLoggedAndThrow(new IllegalArgumentException(
+            "Unrecognized command line option: " + args[index]));
       }
       int minParamCount = option.getMinimumParameterCount();
       int maxParamCount = option.getMaximumParameterCount();

--- a/src/main/java/com/senzing/configmgr/ConfigurationManager.java
+++ b/src/main/java/com/senzing/configmgr/ConfigurationManager.java
@@ -562,7 +562,7 @@ public class ConfigurationManager {
     try {
       options = parseCommandLine(args);
     } catch (Exception e) {
-      e.printStackTrace();
+      if (!isLastLoggedException(e)) e.printStackTrace();
       System.out.println(ConfigurationManager.getUsageString(false));
       System.exit(1);
     }
@@ -621,7 +621,7 @@ public class ConfigurationManager {
       }
 
     } catch (Exception e) {
-      e.printStackTrace();
+      if (!isLastLoggedException(e)) e.printStackTrace();
     }
   }
 

--- a/src/main/java/com/senzing/repomgr/RepositoryManager.java
+++ b/src/main/java/com/senzing/repomgr/RepositoryManager.java
@@ -15,6 +15,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
 
+import static com.senzing.util.LoggingUtilities.isLastLoggedException;
 import static com.senzing.util.OperatingSystemFamily.*;
 import static java.nio.file.StandardCopyOption.*;
 import static com.senzing.io.IOUtilities.*;
@@ -453,6 +454,7 @@ public class RepositoryManager {
     try {
       options = parseCommandLine(args);
     } catch (Exception e) {
+      if (!isLastLoggedException(e)) e.printStackTrace();
       System.out.println(RepositoryManager.getUsageString(false));
       System.exit(1);
     }

--- a/src/main/java/com/senzing/util/LoggingUtilities.java
+++ b/src/main/java/com/senzing/util/LoggingUtilities.java
@@ -4,8 +4,15 @@ import com.senzing.g2.engine.G2Fallible;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.util.Objects;
 
 public class LoggingUtilities {
+  /**
+   * The last logged exception in this thread.
+   */
+  private static final ThreadLocal<Long> LAST_LOGGED_EXCEPTION
+      = new ThreadLocal<>();
+
   /**
    * Private default constructor
    */
@@ -119,4 +126,59 @@ public class LoggingUtilities {
     System.err.println(message);
   }
 
+  /**
+   * Convert a throwable to a {@link Long} value so we don't keep a reference
+   * to what could be a complex exception object.
+   * @param t The throwable to convert.
+   * @return The long hash represetation to identify the throwable instance.
+   */
+  private static Long throwableToLong(Throwable t) {
+    if (t == null) return null;
+    long hash1 = (long) System.identityHashCode(t);
+    StringWriter sw = new StringWriter();
+    PrintWriter pw = new PrintWriter(sw);
+    t.printStackTrace(pw);
+    pw.flush();
+    long hash2 = (long) sw.toString().hashCode();
+    return ((hash1 << 32) | hash2);
+  }
+
+  /**
+   * Checks if the specified {@link Throwable} is the last logged exception.
+   * This is handy for telling if the exception has already been logged by a
+   * deeper level of the stack trace.
+   * @param t The {@link Throwable} to check.
+   * @return <tt>true</tt> if it is the last logged exception, otherwise
+   *         <tt>false</tt>.
+   */
+  public static boolean isLastLoggedException(Throwable t) {
+    if (t == null) return false;
+    if (LAST_LOGGED_EXCEPTION.get() == null) return false;
+    long value = throwableToLong(t);
+    return (LAST_LOGGED_EXCEPTION.get() == value);
+  }
+
+  /**
+   * Checks if the specified {@link Throwable} is the last logged exception.
+   * This is handy for telling if the exception has already been logged by a
+   * deeper level of the stack trace.
+   * @param t The {@link Throwable} to check.
+   * @return <tt>true</tt> if it is the last logged exception, otherwise
+   *         <tt>false</tt>.
+   */
+  public static void setLastLoggedException(Throwable t) {
+    LAST_LOGGED_EXCEPTION.set(throwableToLong(t));
+  }
+
+  /**
+   * Sets the last logged exception and rethrows the specified exception.
+   * @param t The {@link Throwable} describing the exception.
+   * @throws T The specified exception.
+   */
+  public static <T extends Throwable> void setLastLoggedAndThrow(T t)
+    throws T
+  {
+    setLastLoggedException(t);
+    throw t;
+  }
 }

--- a/src/main/java/com/senzing/util/LoggingUtilities.java
+++ b/src/main/java/com/senzing/util/LoggingUtilities.java
@@ -159,12 +159,11 @@ public class LoggingUtilities {
   }
 
   /**
-   * Checks if the specified {@link Throwable} is the last logged exception.
+   * Sets the specified {@link Throwable} as the last logged exception.
    * This is handy for telling if the exception has already been logged by a
    * deeper level of the stack trace.
-   * @param t The {@link Throwable} to check.
-   * @return <tt>true</tt> if it is the last logged exception, otherwise
-   *         <tt>false</tt>.
+   *
+   * @param t The {@link Throwable} to set as the last logged exception.
    */
   public static void setLastLoggedException(Throwable t) {
     LAST_LOGGED_EXCEPTION.set(throwableToLong(t));

--- a/src/test/java/com/senzing/api/GenerateTestJVMScript.java
+++ b/src/test/java/com/senzing/api/GenerateTestJVMScript.java
@@ -103,6 +103,8 @@ public class GenerateTestJVMScript {
         if (RUNTIME_OS_FAMILY == WINDOWS) {
           pw.println("@echo off");
           pw.println("set Path=" + libraryPath + ";%Path%");
+          pw.println("set SENZING_ROOT="
+                         + quote + senzingDir.getCanonicalPath() + quote);
           pw.println("\"" + javaExecutable.toString() + "\" %*");
 
         } else {
@@ -113,6 +115,8 @@ public class GenerateTestJVMScript {
           }
           pw.println("export LD_LIBRARY_PATH=" + libraryPath
                      + ":$LD_LIBRARY_PATH");
+          pw.println("export SENZING_ROOT="
+                     + quote + senzingDir.getCanonicalPath() + quote);
           pw.println("\"" + javaExecutable.toString() + "\" \"$@\"");
         }
       }

--- a/src/test/java/com/senzing/api/services/AbstractServiceTest.java
+++ b/src/test/java/com/senzing/api/services/AbstractServiceTest.java
@@ -65,6 +65,7 @@ public abstract class AbstractServiceTest {
       try {
         engineApi = new G2JNI();
       } catch (Throwable ignore) {
+        ignore.printStackTrace();
         // do nothing
       }
     } finally {
@@ -2044,19 +2045,19 @@ public abstract class AbstractServiceTest {
     if (expectRawData) {
       this.validateRawDataMap(testInfo,
                               response.getRawData(),
-                              true,
+                              false,
                               "RESOLVED_ENTITIES");
 
       Object entities = ((Map) response.getRawData()).get("RESOLVED_ENTITIES");
       this.validateRawDataMapArray(testInfo,
                                    entities,
-                                   true,
+                                   false,
                                    "MATCH_INFO", "ENTITY");
       for (Object obj : ((Collection) entities)) {
         Object matchInfo = ((Map) obj).get("MATCH_INFO");
         this.validateRawDataMap(testInfo,
                                 matchInfo,
-                                true,
+                                false,
                                 "MATCH_LEVEL",
                                 "MATCH_KEY",
                                 "MATCH_SCORE",

--- a/src/test/java/com/senzing/api/services/AdminServicesTest.java
+++ b/src/test/java/com/senzing/api/services/AdminServicesTest.java
@@ -340,6 +340,7 @@ public class AdminServicesTest extends AbstractServiceTest {
     if (expectRawData) {
       this.validateRawDataMap(
           response.getRawData(),
+          false,
           "VERSION", "BUILD_NUMBER", "BUILD_DATE", "COMPATIBILITY_VERSION");
     }
   }


### PR DESCRIPTION
- Added tracking of last exception logged to reduce repetititve output when command line options are invalid.
- Fixed auto tests when building with version 1.11.1 or later of native Senzing libs
- Updated Changelog and updated to version 1.7.4.
