### PR TITLE
Updated SzVersionInfo configCompatibilityVersion to be a string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.5] - 2019-09-17
+
+### Changes in 1.7.5
+
+- Corrected errant definition of SzVersionInfo's `configCompatabilityVersion` 
+field as an integer to make it a string to allow for semantic versioning.  This
+changes the response to the `GET /version` endpoint.
+*NOTE*: This change may require that previously generated client stubs be 
+regenerated to avoid trying to parse the semantic version string as an integer.
+
 ## [1.7.4] - 2019-09-13
 
 ### Changes in 1.7.4

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.senzing</groupId>
   <artifactId>senzing-api-server</artifactId>
   <packaging>jar</packaging>
-  <version>1.7.4</version>
+  <version>1.7.5</version>
   <name>senzing-api-server</name>
   <url>http://maven.apache.org</url>
   <dependencies>

--- a/src/main/java/com/senzing/api/model/SzVersionInfo.java
+++ b/src/main/java/com/senzing/api/model/SzVersionInfo.java
@@ -67,7 +67,7 @@ public class SzVersionInfo {
    * The configuration compatibility version for the underlying runtime
    * native Senzing API.
    */
-  private int configCompatibilityVersion = 0;
+  private String configCompatibilityVersion = null;
 
   /**
    * Default constructor.
@@ -182,7 +182,7 @@ public class SzVersionInfo {
    * @return The configuration compatibility version for the underlying runtime
    *         native Senzing API.
    */
-  public int getConfigCompatibilityVersion() {
+  public String getConfigCompatibilityVersion() {
     return configCompatibilityVersion;
   }
 
@@ -194,7 +194,7 @@ public class SzVersionInfo {
    *                                   for the underlying runtime native
    *                                   Senzing API.
    */
-  public void setConfigCompatibilityVersion(int configCompatibilityVersion) {
+  public void setConfigCompatibilityVersion(String configCompatibilityVersion) {
     this.configCompatibilityVersion = configCompatibilityVersion;
   }
 
@@ -246,8 +246,7 @@ public class SzVersionInfo {
         = JsonUtils.getJsonObject(jsonObject, "COMPATIBILITY_VERSION");
 
     String configCompatVersion = JsonUtils.getString(compatVersion,
-                                                     "CONFIG_VERSION",
-                                                     "-1");
+                                                     "CONFIG_VERSION");
 
     Date buildDate = null;
     if (buildNumber != null && buildNumber.length() > 0) {
@@ -259,7 +258,7 @@ public class SzVersionInfo {
 
     info.setApiServerVersion(BuildInfo.MAVEN_VERSION);
     info.setRestApiVersion(BuildInfo.REST_API_VERSION);
-    info.setConfigCompatibilityVersion(Integer.parseInt(configCompatVersion));
+    info.setConfigCompatibilityVersion(configCompatVersion);
     info.setNativeApiVersion(nativeVersion);
     info.setNativeApiBuildDate(buildDate);
     info.setNativeApiBuildNumber(buildNumber);

--- a/src/test/java/com/senzing/api/services/AdminServicesTest.java
+++ b/src/test/java/com/senzing/api/services/AdminServicesTest.java
@@ -322,8 +322,8 @@ public class AdminServicesTest extends AbstractServiceTest {
       JsonObject subObject = JsonUtils.getJsonObject(
           jsonObject, "COMPATIBILITY_VERSION");
 
-      int configCompatVers = Integer.parseInt(JsonUtils.getString(
-          subObject, "CONFIG_VERSION"));
+      String configCompatVers = JsonUtils.getString(subObject,
+                                                    "CONFIG_VERSION");
 
       assertEquals(expectedVersion, info.getNativeApiVersion(),
                    "Native API Version wrong");


### PR DESCRIPTION
Modified SzVersionInfo so that `configCompatabilityVersion` is represented as a string instead of an integer so that semantic versioning is possible.