### PR TITLE
Address Security Vulnerabilities, fix SzApiServer shutdown, improved error checking and unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.5] - 2019-09-17
+
+### Changes in 1.7.5
+
+- Corrected errant definition of SzVersionInfo's `configCompatabilityVersion` 
+field as an integer to make it a string to allow for semantic versioning.  This
+changes the response to the `GET /version` endpoint.
+*NOTE*: This change may require that previously generated client stubs be 
+regenerated to avoid trying to parse the semantic version string as an integer.
+
 ## [1.7.4] - 2019-09-13
 
 ### Changes in 1.7.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.6] - 2019-09-24
+
+### Changes in 1.7.6
+
+- Updated dependency on FasterBind's Jackson library to version 2.9.10 to 
+address security vulnerabilities.
+- Updated repository manager code used for JUnit tests to check for errors
+when initializing the configuration manager and when creating the standard
+configuration.
+- Updated 
+
 ## [1.7.5] - 2019-09-17
 
 ### Changes in 1.7.5

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.senzing</groupId>
   <artifactId>senzing-api-server</artifactId>
   <packaging>jar</packaging>
-  <version>1.7.4</version>
+  <version>1.7.5</version>
   <name>senzing-api-server</name>
   <url>http://maven.apache.org</url>
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.senzing</groupId>
   <artifactId>senzing-api-server</artifactId>
   <packaging>jar</packaging>
-  <version>1.7.5</version>
+  <version>1.7.6</version>
   <name>senzing-api-server</name>
   <url>http://maven.apache.org</url>
   <dependencies>
@@ -83,17 +83,17 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.9.9</version>
+      <version>2.9.10</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.9.3</version>
+      <version>2.9.10</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>
       <artifactId>jackson-module-jaxb-annotations</artifactId>
-      <version>2.9.9</version>
+      <version>2.9.10</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/src/main/java/com/senzing/api/model/SzVersionInfo.java
+++ b/src/main/java/com/senzing/api/model/SzVersionInfo.java
@@ -67,7 +67,7 @@ public class SzVersionInfo {
    * The configuration compatibility version for the underlying runtime
    * native Senzing API.
    */
-  private int configCompatibilityVersion = 0;
+  private String configCompatibilityVersion = null;
 
   /**
    * Default constructor.
@@ -182,7 +182,7 @@ public class SzVersionInfo {
    * @return The configuration compatibility version for the underlying runtime
    *         native Senzing API.
    */
-  public int getConfigCompatibilityVersion() {
+  public String getConfigCompatibilityVersion() {
     return configCompatibilityVersion;
   }
 
@@ -194,7 +194,7 @@ public class SzVersionInfo {
    *                                   for the underlying runtime native
    *                                   Senzing API.
    */
-  public void setConfigCompatibilityVersion(int configCompatibilityVersion) {
+  public void setConfigCompatibilityVersion(String configCompatibilityVersion) {
     this.configCompatibilityVersion = configCompatibilityVersion;
   }
 
@@ -246,8 +246,7 @@ public class SzVersionInfo {
         = JsonUtils.getJsonObject(jsonObject, "COMPATIBILITY_VERSION");
 
     String configCompatVersion = JsonUtils.getString(compatVersion,
-                                                     "CONFIG_VERSION",
-                                                     "-1");
+                                                     "CONFIG_VERSION");
 
     Date buildDate = null;
     if (buildNumber != null && buildNumber.length() > 0) {
@@ -259,7 +258,7 @@ public class SzVersionInfo {
 
     info.setApiServerVersion(BuildInfo.MAVEN_VERSION);
     info.setRestApiVersion(BuildInfo.REST_API_VERSION);
-    info.setConfigCompatibilityVersion(Integer.parseInt(configCompatVersion));
+    info.setConfigCompatibilityVersion(configCompatVersion);
     info.setNativeApiVersion(nativeVersion);
     info.setNativeApiBuildDate(buildDate);
     info.setNativeApiBuildNumber(buildNumber);

--- a/src/main/java/com/senzing/repomgr/RepositoryManager.java
+++ b/src/main/java/com/senzing/repomgr/RepositoryManager.java
@@ -592,7 +592,7 @@ public class RepositoryManager {
       }
 
       // setup the initial configuration
-      initBaseApis(directory, true);
+      initBaseApis(directory, false);
       try {
         long configId = CONFIG_API.create();
         if (configId < 0) {

--- a/src/test/java/com/senzing/api/services/AbstractServiceTest.java
+++ b/src/test/java/com/senzing/api/services/AbstractServiceTest.java
@@ -176,12 +176,23 @@ public abstract class AbstractServiceTest {
    * initialize and start the Senzing API Server.
    */
   protected void initializeTestEnvironment() {
-    if (!NATIVE_API_AVAILABLE) return;
-    RepositoryManager.createRepo(this.getRepositoryDirectory(), true);
-    this.repoCreated = true;
-    this.prepareRepository();
-    RepositoryManager.conclude();
-    this.initializeServer();
+    try {
+      if (!NATIVE_API_AVAILABLE) return;
+      RepositoryManager.createRepo(this.getRepositoryDirectory(), true);
+      this.repoCreated = true;
+      this.prepareRepository();
+      RepositoryManager.conclude();
+      this.initializeServer();
+    } catch (RuntimeException e) {
+      e.printStackTrace();
+      throw e;
+    } catch (Error e) {
+      e.printStackTrace();
+      throw e;
+    } catch (Exception e) {
+      e.printStackTrace();
+      throw new RuntimeException(e);
+    }
   }
 
   /**

--- a/src/test/java/com/senzing/api/services/AdminServicesTest.java
+++ b/src/test/java/com/senzing/api/services/AdminServicesTest.java
@@ -25,139 +25,147 @@ public class AdminServicesTest extends AbstractServiceTest {
   }
 
   @AfterAll public void teardownEnvironment() {
-    this.teardownTestEnvironment(true);
+    this.teardownTestEnvironment();
   }
 
   @Test public void heartbeatTest() {
-    this.assumeNativeApiAvailable();
-    String  uriText = this.formatServerUri("heartbeat");
-    UriInfo uriInfo = this.newProxyUriInfo(uriText);
+    this.performTest(() -> {
+      String uriText = this.formatServerUri("heartbeat");
+      UriInfo uriInfo = this.newProxyUriInfo(uriText);
 
-    long            before    = System.currentTimeMillis();
-    SzBasicResponse response  = this.adminServices.heartbeat(uriInfo);
-    response.concludeTimers();
-    long            after     = System.currentTimeMillis();
+      long before = System.currentTimeMillis();
+      SzBasicResponse response = this.adminServices.heartbeat(uriInfo);
+      response.concludeTimers();
+      long after = System.currentTimeMillis();
 
-    this.validateBasics(response, uriText, before, after);
+      this.validateBasics(response, uriText, before, after);
+    });
   }
 
   @Test public void heartbeatViaHttpTest() {
-    this.assumeNativeApiAvailable();
-    String  uriText = this.formatServerUri("heartbeat");
-    long    before  = System.currentTimeMillis();
-    SzBasicResponse response
-        = this.invokeServerViaHttp(GET, uriText, SzBasicResponse.class);
-    long after = System.currentTimeMillis();
+    this.performTest(() -> {
+      String  uriText = this.formatServerUri("heartbeat");
+      long    before  = System.currentTimeMillis();
+      SzBasicResponse response
+          = this.invokeServerViaHttp(GET, uriText, SzBasicResponse.class);
+      long after = System.currentTimeMillis();
 
-    this.validateBasics(response, uriText, before, after);
+      this.validateBasics(response, uriText, before, after);
+    });
   }
 
   @Test public void licenseTest() {
-    this.assumeNativeApiAvailable();
-    String  uriText = this.formatServerUri("license");
-    UriInfo uriInfo = this.newProxyUriInfo(uriText);
+    this.performTest(() -> {
+      String  uriText = this.formatServerUri("license");
+      UriInfo uriInfo = this.newProxyUriInfo(uriText);
 
-    long              before    = System.currentTimeMillis();
-    SzLicenseResponse response  = this.adminServices.license(false, uriInfo);
-    response.concludeTimers();
-    long              after     = System.currentTimeMillis();
+      long              before    = System.currentTimeMillis();
+      SzLicenseResponse response  = this.adminServices.license(false, uriInfo);
+      response.concludeTimers();
+      long              after     = System.currentTimeMillis();
 
-    this.validateLicenseResponse(response,
-                                 before,
-                                 after,
-                                 null,
-                                 "EVAL",
-                                 10000);
+      this.validateLicenseResponse(response,
+                                   before,
+                                   after,
+                                   null,
+                                   "EVAL",
+                                   10000);
+    });
   }
 
   @Test public void licenseViaHttpTest() {
-    this.assumeNativeApiAvailable();
-    String  uriText = this.formatServerUri("license");
-    UriInfo uriInfo = this.newProxyUriInfo(uriText);
+    this.performTest(() -> {
+      String  uriText = this.formatServerUri("license");
+      UriInfo uriInfo = this.newProxyUriInfo(uriText);
 
-    long before = System.currentTimeMillis();
-    SzLicenseResponse response
-        = this.invokeServerViaHttp(GET, uriText, SzLicenseResponse.class);
-    long after = System.currentTimeMillis();
+      long before = System.currentTimeMillis();
+      SzLicenseResponse response
+          = this.invokeServerViaHttp(GET, uriText, SzLicenseResponse.class);
+      long after = System.currentTimeMillis();
 
-    this.validateLicenseResponse(response,
-                                 before,
-                                 after,
-                                 null,
-                                 "EVAL",
-                                 10000);
+      this.validateLicenseResponse(response,
+                                   before,
+                                   after,
+                                   null,
+                                   "EVAL",
+                                   10000);
+    });
   }
 
   @Test public void licenseWithoutRawTest() {
-    this.assumeNativeApiAvailable();
-    String  uriText = this.formatServerUri("license?withRaw=false");
-    UriInfo uriInfo = this.newProxyUriInfo(uriText);
+    this.performTest(() -> {
+      String  uriText = this.formatServerUri("license?withRaw=false");
+      UriInfo uriInfo = this.newProxyUriInfo(uriText);
 
-    long              before    = System.currentTimeMillis();
-    SzLicenseResponse response  = this.adminServices.license(false, uriInfo);
-    response.concludeTimers();
-    long              after     = System.currentTimeMillis();
+      long              before    = System.currentTimeMillis();
+      SzLicenseResponse response  = this.adminServices.license(false, uriInfo);
+      response.concludeTimers();
+      long              after     = System.currentTimeMillis();
 
-    this.validateLicenseResponse(response,
-                                 before,
-                                 after,
-                                 false,
-                                 "EVAL",
-                                 10000);
+      this.validateLicenseResponse(response,
+                                   before,
+                                   after,
+                                   false,
+                                   "EVAL",
+                                   10000);
+
+    });
   }
 
   @Test public void licenseWithoutRawViaHttpTest() {
-    this.assumeNativeApiAvailable();
-    String  uriText = this.formatServerUri("license?withRaw=false");
+    this.performTest(() -> {
+      String  uriText = this.formatServerUri("license?withRaw=false");
 
-    long before = System.currentTimeMillis();
-    SzLicenseResponse response
-        = this.invokeServerViaHttp(GET, uriText, SzLicenseResponse.class);
-    long after = System.currentTimeMillis();
+      long before = System.currentTimeMillis();
+      SzLicenseResponse response
+          = this.invokeServerViaHttp(GET, uriText, SzLicenseResponse.class);
+      long after = System.currentTimeMillis();
 
-    this.validateLicenseResponse(response,
-                                 before,
-                                 after,
-                                 false,
-                                 "EVAL",
-                                 10000);
+      this.validateLicenseResponse(response,
+                                   before,
+                                   after,
+                                   false,
+                                   "EVAL",
+                                   10000);
+    });
   }
 
   @Test public void licenseWithRawTest() {
-    this.assumeNativeApiAvailable();
-    String  uriText = this.formatServerUri("license?withRaw=true");
-    UriInfo uriInfo = this.newProxyUriInfo(uriText);
+    this.performTest(() -> {
+      String  uriText = this.formatServerUri("license?withRaw=true");
+      UriInfo uriInfo = this.newProxyUriInfo(uriText);
 
-    long              before    = System.currentTimeMillis();
-    SzLicenseResponse response  = this.adminServices.license(true, uriInfo);
-    response.concludeTimers();
-    long              after     = System.currentTimeMillis();
+      long              before    = System.currentTimeMillis();
+      SzLicenseResponse response  = this.adminServices.license(true, uriInfo);
+      response.concludeTimers();
+      long              after     = System.currentTimeMillis();
 
-    this.validateLicenseResponse(response,
-                                 before,
-                                 after,
-                                 true,
-                                 "EVAL",
-                                 10000);
+      this.validateLicenseResponse(response,
+                                   before,
+                                   after,
+                                   true,
+                                   "EVAL",
+                                   10000);
+    });
   }
 
   @Test public void licenseWithRawViaHttpTest() {
-    this.assumeNativeApiAvailable();
-    String uriText = this.formatServerUri("license?withRaw=true");
+    this.performTest(()-> {
+      String uriText = this.formatServerUri("license?withRaw=true");
 
-    long before = System.currentTimeMillis();
-    SzLicenseResponse response
-        = this.invokeServerViaHttp(GET, uriText, SzLicenseResponse.class);
-    long after = System.currentTimeMillis();
+      long before = System.currentTimeMillis();
+      SzLicenseResponse response
+          = this.invokeServerViaHttp(GET, uriText, SzLicenseResponse.class);
+      long after = System.currentTimeMillis();
 
-    this.validateLicenseResponse(response,
-                                 before,
-                                 after,
-                                 true,
-                                 "EVAL",
-                                 10000);
+      this.validateLicenseResponse(response,
+                                   before,
+                                   after,
+                                   true,
+                                   "EVAL",
+                                   10000);
+    });
   }
-
 
   private void validateLicenseResponse(SzLicenseResponse  response,
                                        long               beforeTimestamp,

--- a/src/test/java/com/senzing/api/services/AdminServicesTest.java
+++ b/src/test/java/com/senzing/api/services/AdminServicesTest.java
@@ -322,8 +322,8 @@ public class AdminServicesTest extends AbstractServiceTest {
       JsonObject subObject = JsonUtils.getJsonObject(
           jsonObject, "COMPATIBILITY_VERSION");
 
-      int configCompatVers = Integer.parseInt(JsonUtils.getString(
-          subObject, "CONFIG_VERSION"));
+      String configCompatVers = JsonUtils.getString(subObject,
+                                                    "CONFIG_VERSION");
 
       assertEquals(expectedVersion, info.getNativeApiVersion(),
                    "Native API Version wrong");

--- a/src/test/java/com/senzing/api/services/AutoReinitializeTest.java
+++ b/src/test/java/com/senzing/api/services/AutoReinitializeTest.java
@@ -105,131 +105,137 @@ public class AutoReinitializeTest extends AbstractServiceTest
   }
 
   @AfterAll public void teardownEnvironment() {
-    this.teardownTestEnvironment(true);
+    this.teardownTestEnvironment();
     if (this.configMgrApi != null) this.configMgrApi.destroy();
     if (this.configApi != null) this.configApi.destroy();
   }
 
   @Test public void getDataSourcesTest() {
-    this.assumeNativeApiAvailable();
-    final String newDataSource = "FOO";
-    String  uriText = this.formatServerUri("data-sources");
-    UriInfo uriInfo = this.newProxyUriInfo(uriText);
+    this.performTest(()-> {
+      final String newDataSource = "FOO";
+      String  uriText = this.formatServerUri("data-sources");
+      UriInfo uriInfo = this.newProxyUriInfo(uriText);
 
-    this.addDataSource(newDataSource);
+      this.addDataSource(newDataSource);
 
-    // now sleep for 1 second longer than the config refresh period
-    try {
-      Thread.sleep(SzApiServer.CONFIG_REFRESH_PERIOD + 1000L);
-    } catch (InterruptedException ignore) {
-      fail("Interrupted while sleeping and waiting for config refresh.");
-    }
+      // now sleep for 1 second longer than the config refresh period
+      try {
+        Thread.sleep(SzApiServer.CONFIG_REFRESH_PERIOD + 1000L);
+      } catch (InterruptedException ignore) {
+        fail("Interrupted while sleeping and waiting for config refresh.");
+      }
 
-    // now retry the request to get the data sources
-    long before = System.currentTimeMillis();
-    SzDataSourcesResponse response
-        = this.configServices.getDataSources(false, uriInfo);
-    response.concludeTimers();
-    long after = System.currentTimeMillis();
+      // now retry the request to get the data sources
+      long before = System.currentTimeMillis();
+      SzDataSourcesResponse response
+          = this.configServices.getDataSources(false, uriInfo);
+      response.concludeTimers();
+      long after = System.currentTimeMillis();
 
-    synchronized (this.expectedDataSources) {
-      this.validateDataSourcesResponse(response,
-                                       before,
-                                       after,
-                                       null,
-                                       this.expectedDataSources);
-    }
+      synchronized (this.expectedDataSources) {
+        this.validateDataSourcesResponse(response,
+                                         before,
+                                         after,
+                                         null,
+                                         this.expectedDataSources);
+      }
+    });
   }
 
   @Test public void getCurrentConfigTest() {
-    final String newDataSource = "PHOO";
-    this.assumeNativeApiAvailable();
-    String  uriText = this.formatServerUri("config/current");
-    UriInfo uriInfo = this.newProxyUriInfo(uriText);
+    this.performTest(() -> {
+      final String newDataSource = "PHOO";
+      this.assumeNativeApiAvailable();
+      String  uriText = this.formatServerUri("config/current");
+      UriInfo uriInfo = this.newProxyUriInfo(uriText);
 
-    this.addDataSource(newDataSource);
+      this.addDataSource(newDataSource);
 
-    // now sleep for 1 second longer than the config refresh period
-    try {
-      Thread.sleep(SzApiServer.CONFIG_REFRESH_PERIOD + 1000L);
-    } catch (InterruptedException ignore) {
-      fail("Interrupted while sleeping and waiting for config refresh.");
-    }
+      // now sleep for 1 second longer than the config refresh period
+      try {
+        Thread.sleep(SzApiServer.CONFIG_REFRESH_PERIOD + 1000L);
+      } catch (InterruptedException ignore) {
+        fail("Interrupted while sleeping and waiting for config refresh.");
+      }
 
-    long before = System.currentTimeMillis();
-    SzConfigResponse response
-        = this.configServices.getCurrentConfig(uriInfo);
-    response.concludeTimers();
-    long after = System.currentTimeMillis();
+      long before = System.currentTimeMillis();
+      SzConfigResponse response
+          = this.configServices.getCurrentConfig(uriInfo);
+      response.concludeTimers();
+      long after = System.currentTimeMillis();
 
-    synchronized (this.expectedDataSources) {
-      this.validateConfigResponse(response,
-                                  uriText,
-                                  before,
-                                  after,
-                                  this.expectedDataSources);
-    }
+      synchronized (this.expectedDataSources) {
+        this.validateConfigResponse(response,
+                                    uriText,
+                                    before,
+                                    after,
+                                    this.expectedDataSources);
+      }
+    });
   }
 
-
   @Test public void postRecordTest() {
-    final String newDataSource = "FOOX";
-    this.assumeNativeApiAvailable();
-    String  uriText = this.formatServerUri(
-        "data-sources/" + newDataSource + "/records");
-    UriInfo uriInfo = this.newProxyUriInfo(uriText);
+    this.performTest(() -> {
+      final String newDataSource = "FOOX";
+      this.assumeNativeApiAvailable();
+      String  uriText = this.formatServerUri(
+          "data-sources/" + newDataSource + "/records");
+      UriInfo uriInfo = this.newProxyUriInfo(uriText);
 
-    JsonObjectBuilder job = Json.createObjectBuilder();
-    job.add("NAME_FIRST", "Joe");
-    job.add("NAME_LAST", "Schmoe");
-    job.add("PHONE_NUMBER", "702-555-1212");
-    job.add("ADDR_FULL", "101 Main Street, Las Vegas, NV 89101");
-    JsonObject  jsonObject  = job.build();
-    String      jsonText    = JsonUtils.toJsonText(jsonObject);
+      JsonObjectBuilder job = Json.createObjectBuilder();
+      job.add("NAME_FIRST", "Joe");
+      job.add("NAME_LAST", "Schmoe");
+      job.add("PHONE_NUMBER", "702-555-1212");
+      job.add("ADDR_FULL", "101 Main Street, Las Vegas, NV 89101");
+      JsonObject  jsonObject  = job.build();
+      String      jsonText    = JsonUtils.toJsonText(jsonObject);
 
-    // add the data source (so it is there for retry)
-    this.addDataSource(newDataSource);
+      // add the data source (so it is there for retry)
+      this.addDataSource(newDataSource);
 
-    // now add the record -- this should succeed on retry
-    long before = System.currentTimeMillis();
-    SzLoadRecordResponse response = this.entityDataServices.loadRecord(
-        newDataSource, null, uriInfo, jsonText);
-    response.concludeTimers();
-    long after = System.currentTimeMillis();
+      // now add the record -- this should succeed on retry
+      long before = System.currentTimeMillis();
+      SzLoadRecordResponse response = this.entityDataServices.loadRecord(
+          newDataSource, null, uriInfo, jsonText);
+      response.concludeTimers();
+      long after = System.currentTimeMillis();
 
-    this.validateLoadRecordResponse(
-        response, POST, newDataSource, null, before, after);
+      this.validateLoadRecordResponse(
+          response, POST, newDataSource, null, before, after);
+    });
   }
 
   @Test public void putRecordTest() {
-    final String recordId = "ABC123";
-    final String newDataSource = "PHOOX";
+    this.performTest(() -> {
+      final String recordId = "ABC123";
+      final String newDataSource = "PHOOX";
 
-    this.assumeNativeApiAvailable();
-    String  uriText = this.formatServerUri(
-        "data-sources/" + newDataSource + "/records/" + recordId);
-    UriInfo uriInfo = this.newProxyUriInfo(uriText);
+      this.assumeNativeApiAvailable();
+      String  uriText = this.formatServerUri(
+          "data-sources/" + newDataSource + "/records/" + recordId);
+      UriInfo uriInfo = this.newProxyUriInfo(uriText);
 
-    JsonObjectBuilder job = Json.createObjectBuilder();
-    job.add("NAME_FIRST", "John");
-    job.add("NAME_LAST", "Doe");
-    job.add("PHONE_NUMBER", "818-555-1313");
-    job.add("ADDR_FULL", "100 Main Street, Los Angeles, CA 90012");
-    JsonObject  jsonObject  = job.build();
-    String      jsonText    = JsonUtils.toJsonText(jsonObject);
+      JsonObjectBuilder job = Json.createObjectBuilder();
+      job.add("NAME_FIRST", "John");
+      job.add("NAME_LAST", "Doe");
+      job.add("PHONE_NUMBER", "818-555-1313");
+      job.add("ADDR_FULL", "100 Main Street, Los Angeles, CA 90012");
+      JsonObject  jsonObject  = job.build();
+      String      jsonText    = JsonUtils.toJsonText(jsonObject);
 
-    // add the data source (so it is there for retry)
-    this.addDataSource(newDataSource);
+      // add the data source (so it is there for retry)
+      this.addDataSource(newDataSource);
 
-    // now add the record -- this should succeed on retry
-    long before = System.currentTimeMillis();
-    SzLoadRecordResponse response = this.entityDataServices.loadRecord(
-        newDataSource, recordId, null, uriInfo, jsonText);
-    response.concludeTimers();
-    long after = System.currentTimeMillis();
+      // now add the record -- this should succeed on retry
+      long before = System.currentTimeMillis();
+      SzLoadRecordResponse response = this.entityDataServices.loadRecord(
+          newDataSource, recordId, null, uriInfo, jsonText);
+      response.concludeTimers();
+      long after = System.currentTimeMillis();
 
-    this.validateLoadRecordResponse(
-        response, PUT, newDataSource, recordId, before, after);
+      this.validateLoadRecordResponse(
+          response, PUT, newDataSource, recordId, before, after);
+    });
   }
 
   protected void addDataSource(String newDataSource) {

--- a/src/test/java/com/senzing/api/services/ConfigServicesTest.java
+++ b/src/test/java/com/senzing/api/services/ConfigServicesTest.java
@@ -219,266 +219,276 @@ public class ConfigServicesTest extends AbstractServiceTest
   }
 
   @Test public void getDataSourcesTest() {
-    this.assumeNativeApiAvailable();
-    String  uriText = this.formatServerUri("data-sources");
-    UriInfo uriInfo = this.newProxyUriInfo(uriText);
+    this.performTest(() -> {
+      String  uriText = this.formatServerUri("data-sources");
+      UriInfo uriInfo = this.newProxyUriInfo(uriText);
 
-    long            before    = System.currentTimeMillis();
-    SzDataSourcesResponse response
-        = this.configServices.getDataSources(false, uriInfo);
-    response.concludeTimers();
-    long            after     = System.currentTimeMillis();
+      long            before    = System.currentTimeMillis();
+      SzDataSourcesResponse response
+          = this.configServices.getDataSources(false, uriInfo);
+      response.concludeTimers();
+      long            after     = System.currentTimeMillis();
 
-    this.validateDataSourcesResponse(response,
-                                     before,
-                                     after,
-                                     null,
-                                     EXPECTED_DATA_SOURCES);
+      this.validateDataSourcesResponse(response,
+                                       before,
+                                       after,
+                                       null,
+                                       EXPECTED_DATA_SOURCES);
+    });
   }
 
   @Test public void getDataSourcesViaHttpTest() {
-    this.assumeNativeApiAvailable();
-    String  uriText = this.formatServerUri("data-sources");
-    long    before  = System.currentTimeMillis();
-    SzDataSourcesResponse response
-        = this.invokeServerViaHttp(GET, uriText, SzDataSourcesResponse.class);
-    long after = System.currentTimeMillis();
+    this.performTest(() -> {
+      String  uriText = this.formatServerUri("data-sources");
+      long    before  = System.currentTimeMillis();
+      SzDataSourcesResponse response
+          = this.invokeServerViaHttp(GET, uriText, SzDataSourcesResponse.class);
+      long after = System.currentTimeMillis();
 
-    this.validateDataSourcesResponse(response,
-                                     before,
-                                     after,
-                                     null,
-                                     EXPECTED_DATA_SOURCES);
+      this.validateDataSourcesResponse(response,
+                                       before,
+                                       after,
+                                       null,
+                                       EXPECTED_DATA_SOURCES);
+    });
   }
 
   @Test public void getDataSourcesWithoutRawTest() {
-    this.assumeNativeApiAvailable();
-    String  uriText = this.formatServerUri("data-sources?withRaw=false");
-    UriInfo uriInfo = this.newProxyUriInfo(uriText);
+    this.performTest(() -> {
+      String  uriText = this.formatServerUri("data-sources?withRaw=false");
+      UriInfo uriInfo = this.newProxyUriInfo(uriText);
 
-    long            before    = System.currentTimeMillis();
-    SzDataSourcesResponse response
-        = this.configServices.getDataSources(false, uriInfo);
-    response.concludeTimers();
-    long            after     = System.currentTimeMillis();
+      long            before    = System.currentTimeMillis();
+      SzDataSourcesResponse response
+          = this.configServices.getDataSources(false, uriInfo);
+      response.concludeTimers();
+      long            after     = System.currentTimeMillis();
 
-    this.validateDataSourcesResponse(response,
-                                     before,
-                                     after,
-                                     false,
-                                     EXPECTED_DATA_SOURCES);
+      this.validateDataSourcesResponse(response,
+                                       before,
+                                       after,
+                                       false,
+                                       EXPECTED_DATA_SOURCES);
+    });
   }
 
   @Test public void getDataSourcesWithoutRawViaHttpTest() {
-    this.assumeNativeApiAvailable();
-    String  uriText = this.formatServerUri("data-sources?withRaw=false");
-    long    before  = System.currentTimeMillis();
-    SzDataSourcesResponse response
-        = this.invokeServerViaHttp(GET, uriText, SzDataSourcesResponse.class);
-    long after = System.currentTimeMillis();
+    this.performTest(() -> {
+      String  uriText = this.formatServerUri("data-sources?withRaw=false");
+      long    before  = System.currentTimeMillis();
+      SzDataSourcesResponse response
+          = this.invokeServerViaHttp(GET, uriText, SzDataSourcesResponse.class);
+      long after = System.currentTimeMillis();
 
-    this.validateDataSourcesResponse(response,
-                                     before,
-                                     after,
-                                     false,
-                                     EXPECTED_DATA_SOURCES);
+      this.validateDataSourcesResponse(response,
+                                       before,
+                                       after,
+                                       false,
+                                       EXPECTED_DATA_SOURCES);
+    });
   }
 
   @Test public void getDataSourcesWithRawTest() {
-    this.assumeNativeApiAvailable();
-    String  uriText = this.formatServerUri("data-sources?withRaw=true");
-    UriInfo uriInfo = this.newProxyUriInfo(uriText);
+    this.performTest(() -> {
+      String  uriText = this.formatServerUri("data-sources?withRaw=true");
+      UriInfo uriInfo = this.newProxyUriInfo(uriText);
 
-    long            before    = System.currentTimeMillis();
-    SzDataSourcesResponse response
-        = this.configServices.getDataSources(true, uriInfo);
-    response.concludeTimers();
-    long            after     = System.currentTimeMillis();
+      long            before    = System.currentTimeMillis();
+      SzDataSourcesResponse response
+          = this.configServices.getDataSources(true, uriInfo);
+      response.concludeTimers();
+      long            after     = System.currentTimeMillis();
 
-    this.validateDataSourcesResponse(response,
-                                     before,
-                                     after,
-                                     true,
-                                     EXPECTED_DATA_SOURCES);
+      this.validateDataSourcesResponse(response,
+                                       before,
+                                       after,
+                                       true,
+                                       EXPECTED_DATA_SOURCES);
+    });
   }
 
   @Test public void getDataSourcesWithRawViaHttpTest() {
-    this.assumeNativeApiAvailable();
-    String  uriText = this.formatServerUri("data-sources?withRaw=true");
-    long    before  = System.currentTimeMillis();
-    SzDataSourcesResponse response
-        = this.invokeServerViaHttp(GET, uriText, SzDataSourcesResponse.class);
-    long after = System.currentTimeMillis();
+    this.performTest(() -> {
+      String  uriText = this.formatServerUri("data-sources?withRaw=true");
+      long    before  = System.currentTimeMillis();
+      SzDataSourcesResponse response
+          = this.invokeServerViaHttp(GET, uriText, SzDataSourcesResponse.class);
+      long after = System.currentTimeMillis();
 
-    this.validateDataSourcesResponse(response,
-                                     before,
-                                     after,
-                                     true,
-                                     EXPECTED_DATA_SOURCES);
+      this.validateDataSourcesResponse(response,
+                                       before,
+                                       after,
+                                       true,
+                                       EXPECTED_DATA_SOURCES);
+    });
   }
 
   @Test public void getAttributeTypesTest() {
-    this.assumeNativeApiAvailable();
-    String  uriText = this.formatServerUri("attribute-types");
-    UriInfo uriInfo = this.newProxyUriInfo(uriText);
+    this.performTest(() -> {
+      String  uriText = this.formatServerUri("attribute-types");
+      UriInfo uriInfo = this.newProxyUriInfo(uriText);
 
-    long before = System.currentTimeMillis();
-    SzAttributeTypesResponse response
-        = this.configServices.getAttributeTypes(false,
-                                                null,
-                                                null,
-                                                false,
-                                                uriInfo);
-    response.concludeTimers();
-    long after = System.currentTimeMillis();
+      long before = System.currentTimeMillis();
+      SzAttributeTypesResponse response
+          = this.configServices.getAttributeTypes(false,
+                                                  null,
+                                                  null,
+                                                  false,
+                                                  uriInfo);
+      response.concludeTimers();
+      long after = System.currentTimeMillis();
 
-    this.validateAttributeTypesResponse(response,
-                                        uriText,
-                                        before,
-                                        after,
-                                        null,
-                                        this.standardAttrTypes);
-
+      this.validateAttributeTypesResponse(response,
+                                          uriText,
+                                          before,
+                                          after,
+                                          null,
+                                          this.standardAttrTypes);
+    });
   }
 
   @Test public void getAttributeTypesViaHttpTest() {
-    this.assumeNativeApiAvailable();
-    String  uriText = this.formatServerUri("attribute-types");
-    long    before  = System.currentTimeMillis();
-    SzAttributeTypesResponse response
-        = this.invokeServerViaHttp(GET, uriText, SzAttributeTypesResponse.class);
-    long after = System.currentTimeMillis();
+    this.performTest(() -> {
+      String  uriText = this.formatServerUri("attribute-types");
+      long    before  = System.currentTimeMillis();
+      SzAttributeTypesResponse response
+          = this.invokeServerViaHttp(GET, uriText, SzAttributeTypesResponse.class);
+      long after = System.currentTimeMillis();
 
-    this.validateAttributeTypesResponse(response,
-                                        uriText,
-                                        before,
-                                        after,
-                                        null,
-                                        this.standardAttrTypes);
+      this.validateAttributeTypesResponse(response,
+                                          uriText,
+                                          before,
+                                          after,
+                                          null,
+                                          this.standardAttrTypes);
+    });
   }
 
   @Test public void getAttributeTypesWithRawTest() {
-    this.assumeNativeApiAvailable();
-    String  uriText = this.formatServerUri("attribute-types?withRaw=true");
-    UriInfo uriInfo = this.newProxyUriInfo(uriText);
+    this.performTest(() -> {
+      String  uriText = this.formatServerUri("attribute-types?withRaw=true");
+      UriInfo uriInfo = this.newProxyUriInfo(uriText);
 
-    long before = System.currentTimeMillis();
-    SzAttributeTypesResponse response
-        = this.configServices.getAttributeTypes(false,
-                                                null,
-                                                null,
-                                                true,
-                                                uriInfo);
-    response.concludeTimers();
-    long after = System.currentTimeMillis();
+      long before = System.currentTimeMillis();
+      SzAttributeTypesResponse response
+          = this.configServices.getAttributeTypes(false,
+                                                  null,
+                                                  null,
+                                                  true,
+                                                  uriInfo);
+      response.concludeTimers();
+      long after = System.currentTimeMillis();
 
-    this.validateAttributeTypesResponse(response,
-                                        uriText,
-                                        before,
-                                        after,
-                                        true,
-                                        this.standardAttrTypes);
-
+      this.validateAttributeTypesResponse(response,
+                                          uriText,
+                                          before,
+                                          after,
+                                          true,
+                                          this.standardAttrTypes);
+    });
   }
 
   @Test public void getAttributeTypesWithRawViaHttpTest() {
-    this.assumeNativeApiAvailable();
-    String  uriText = this.formatServerUri("attribute-types?withRaw=true");
-    long    before  = System.currentTimeMillis();
-    SzAttributeTypesResponse response
-        = this.invokeServerViaHttp(GET, uriText, SzAttributeTypesResponse.class);
-    long after = System.currentTimeMillis();
+    this.performTest(() -> {
+      String  uriText = this.formatServerUri("attribute-types?withRaw=true");
+      long    before  = System.currentTimeMillis();
+      SzAttributeTypesResponse response
+          = this.invokeServerViaHttp(GET, uriText, SzAttributeTypesResponse.class);
+      long after = System.currentTimeMillis();
 
-    this.validateAttributeTypesResponse(response,
-                                        uriText,
-                                        before,
-                                        after,
-                                        true,
-                                        this.standardAttrTypes);
+      this.validateAttributeTypesResponse(response,
+                                          uriText,
+                                          before,
+                                          after,
+                                          true,
+                                          this.standardAttrTypes);
+    });
   }
 
   @Test public void getAttributeTypesWithoutInternalTest() {
-    this.assumeNativeApiAvailable();
-    String  uriText = this.formatServerUri(
-        "attribute-types?withInternal=false");
-    UriInfo uriInfo = this.newProxyUriInfo(uriText);
+    this.performTest(() -> {
+      String  uriText = this.formatServerUri(
+          "attribute-types?withInternal=false");
+      UriInfo uriInfo = this.newProxyUriInfo(uriText);
 
-    long before = System.currentTimeMillis();
-    SzAttributeTypesResponse response
-        = this.configServices.getAttributeTypes(false,
-                                                null,
-                                                null,
-                                                false,
-                                                uriInfo);
-    response.concludeTimers();
-    long after = System.currentTimeMillis();
+      long before = System.currentTimeMillis();
+      SzAttributeTypesResponse response
+          = this.configServices.getAttributeTypes(false,
+                                                  null,
+                                                  null,
+                                                  false,
+                                                  uriInfo);
+      response.concludeTimers();
+      long after = System.currentTimeMillis();
 
-    this.validateAttributeTypesResponse(response,
-                                        uriText,
-                                        before,
-                                        after,
-                                        null,
-                                        this.standardAttrTypes);
-
+      this.validateAttributeTypesResponse(response,
+                                          uriText,
+                                          before,
+                                          after,
+                                          null,
+                                          this.standardAttrTypes);
+    });
   }
 
   @Test public void getAttributeTypesWithoutInternalViaHttpTest() {
-    this.assumeNativeApiAvailable();
-    String  uriText = this.formatServerUri(
-        "attribute-types?withInternal=false");
-    long    before  = System.currentTimeMillis();
-    SzAttributeTypesResponse response
-        = this.invokeServerViaHttp(GET, uriText, SzAttributeTypesResponse.class);
-    long after = System.currentTimeMillis();
+    this.performTest(() -> {
+      String  uriText = this.formatServerUri(
+          "attribute-types?withInternal=false");
+      long    before  = System.currentTimeMillis();
+      SzAttributeTypesResponse response
+          = this.invokeServerViaHttp(GET, uriText, SzAttributeTypesResponse.class);
+      long after = System.currentTimeMillis();
 
-    this.validateAttributeTypesResponse(response,
-                                        uriText,
-                                        before,
-                                        after,
-                                        null,
-                                        this.standardAttrTypes);
+      this.validateAttributeTypesResponse(response,
+                                          uriText,
+                                          before,
+                                          after,
+                                          null,
+                                          this.standardAttrTypes);
+    });
   }
 
   @Test public void getAttributeTypesWithInternalTest() {
-    this.assumeNativeApiAvailable();
-    String  uriText = this.formatServerUri(
-        "attribute-types?withInternal=true");
-    UriInfo uriInfo = this.newProxyUriInfo(uriText);
+    this.performTest(() -> {
+      String  uriText = this.formatServerUri(
+          "attribute-types?withInternal=true");
+      UriInfo uriInfo = this.newProxyUriInfo(uriText);
 
-    long before = System.currentTimeMillis();
-    SzAttributeTypesResponse response
-        = this.configServices.getAttributeTypes(true,
-                                                null,
-                                                null,
-                                                false,
-                                                uriInfo);
-    response.concludeTimers();
-    long after = System.currentTimeMillis();
+      long before = System.currentTimeMillis();
+      SzAttributeTypesResponse response
+          = this.configServices.getAttributeTypes(true,
+                                                  null,
+                                                  null,
+                                                  false,
+                                                  uriInfo);
+      response.concludeTimers();
+      long after = System.currentTimeMillis();
 
-    this.validateAttributeTypesResponse(response,
-                                        uriText,
-                                        before,
-                                        after,
-                                        null,
-                                        this.allAttrTypes);
-
+      this.validateAttributeTypesResponse(response,
+                                          uriText,
+                                          before,
+                                          after,
+                                          null,
+                                          this.allAttrTypes);
+    });
   }
 
   @Test public void getAttributeTypesWithInternalViaHttpTest() {
-    this.assumeNativeApiAvailable();
-    String  uriText = this.formatServerUri(
-        "attribute-types?withInternal=true");
-    long    before  = System.currentTimeMillis();
-    SzAttributeTypesResponse response
-        = this.invokeServerViaHttp(GET, uriText, SzAttributeTypesResponse.class);
-    long after = System.currentTimeMillis();
+    this.performTest(() -> {
+      String  uriText = this.formatServerUri(
+          "attribute-types?withInternal=true");
+      long    before  = System.currentTimeMillis();
+      SzAttributeTypesResponse response
+          = this.invokeServerViaHttp(GET, uriText, SzAttributeTypesResponse.class);
+      long after = System.currentTimeMillis();
 
-    this.validateAttributeTypesResponse(response,
-                                        uriText,
-                                        before,
-                                        after,
-                                        null,
-                                        this.allAttrTypes);
+      this.validateAttributeTypesResponse(response,
+                                          uriText,
+                                          before,
+                                          after,
+                                          null,
+                                          this.allAttrTypes);
+    });
   }
 
   private Set<SzAttributeClass> allAttributeClasses() {
@@ -492,98 +502,100 @@ public class ConfigServicesTest extends AbstractServiceTest
   @ParameterizedTest
   @MethodSource("standardAttributeClasses")
   public void getAttributeTypesForClassTest(SzAttributeClass attrClass) {
-    this.assumeNativeApiAvailable();
-    Set<String> attrTypes = this.standardAttrTypesByClass.get(attrClass);
-    String  uriText = this.formatServerUri(
-        "attribute-types?attributeClass=" + attrClass);
-    UriInfo uriInfo = this.newProxyUriInfo(uriText);
+    this.performTest(() -> {
+      Set<String> attrTypes = this.standardAttrTypesByClass.get(attrClass);
+      String  uriText = this.formatServerUri(
+          "attribute-types?attributeClass=" + attrClass);
+      UriInfo uriInfo = this.newProxyUriInfo(uriText);
 
-    long before = System.currentTimeMillis();
-    SzAttributeTypesResponse response
-        = this.configServices.getAttributeTypes(false,
-                                                attrClass.toString(),
-                                                null,
-                                                false,
-                                                uriInfo);
-    response.concludeTimers();
-    long after = System.currentTimeMillis();
+      long before = System.currentTimeMillis();
+      SzAttributeTypesResponse response
+          = this.configServices.getAttributeTypes(false,
+                                                  attrClass.toString(),
+                                                  null,
+                                                  false,
+                                                  uriInfo);
+      response.concludeTimers();
+      long after = System.currentTimeMillis();
 
-    this.validateAttributeTypesResponse(response,
-                                        uriText,
-                                        before,
-                                        after,
-                                        null,
-                                        attrTypes);
-
+      this.validateAttributeTypesResponse(response,
+                                          uriText,
+                                          before,
+                                          after,
+                                          null,
+                                          attrTypes);
+    });
   }
 
   @ParameterizedTest
   @MethodSource("standardAttributeClasses")
   public void getAttributeTypesForClassViaHttpTest(SzAttributeClass attrClass) {
-    this.assumeNativeApiAvailable();
-    Set<String> attrTypes = this.standardAttrTypesByClass.get(attrClass);
-    String  uriText = this.formatServerUri(
-        "attribute-types?attributeClass=" + attrClass);
-    long    before  = System.currentTimeMillis();
-    SzAttributeTypesResponse response
-        = this.invokeServerViaHttp(GET, uriText, SzAttributeTypesResponse.class);
-    long after = System.currentTimeMillis();
+    this.performTest(() -> {
+      Set<String> attrTypes = this.standardAttrTypesByClass.get(attrClass);
+      String  uriText = this.formatServerUri(
+          "attribute-types?attributeClass=" + attrClass);
+      long    before  = System.currentTimeMillis();
+      SzAttributeTypesResponse response
+          = this.invokeServerViaHttp(GET, uriText, SzAttributeTypesResponse.class);
+      long after = System.currentTimeMillis();
 
-    this.validateAttributeTypesResponse(response,
-                                        uriText,
-                                        before,
-                                        after,
-                                        null,
-                                        attrTypes);
+      this.validateAttributeTypesResponse(response,
+                                          uriText,
+                                          before,
+                                          after,
+                                          null,
+                                          attrTypes);
+    });
   }
 
   @ParameterizedTest
   @MethodSource("allAttributeClasses")
   public void getAttributeTypesForClassWithInternalTest(SzAttributeClass attrClass) {
-    this.assumeNativeApiAvailable();
-    Set<String> attrTypes = this.allAttrTypesByClass.get(attrClass);
-    String  uriText = this.formatServerUri(
-        "attribute-types?withInternal=true&attributeClass=" + attrClass);
-    UriInfo uriInfo = this.newProxyUriInfo(uriText);
+    this.performTest(() -> {
+      Set<String> attrTypes = this.allAttrTypesByClass.get(attrClass);
+      String  uriText = this.formatServerUri(
+          "attribute-types?withInternal=true&attributeClass=" + attrClass);
+      UriInfo uriInfo = this.newProxyUriInfo(uriText);
 
-    long before = System.currentTimeMillis();
-    SzAttributeTypesResponse response
-        = this.configServices.getAttributeTypes(true,
-                                                attrClass.toString(),
-                                                null,
-                                                false,
-                                                uriInfo);
-    response.concludeTimers();
-    long after = System.currentTimeMillis();
+      long before = System.currentTimeMillis();
+      SzAttributeTypesResponse response
+          = this.configServices.getAttributeTypes(true,
+                                                  attrClass.toString(),
+                                                  null,
+                                                  false,
+                                                  uriInfo);
+      response.concludeTimers();
+      long after = System.currentTimeMillis();
 
-    this.validateAttributeTypesResponse(response,
-                                        uriText,
-                                        before,
-                                        after,
-                                        null,
-                                        attrTypes);
-
+      this.validateAttributeTypesResponse(response,
+                                          uriText,
+                                          before,
+                                          after,
+                                          null,
+                                          attrTypes);
+    });
   }
 
   @ParameterizedTest
   @MethodSource("allAttributeClasses")
   public void getAttributeTypesForClassWithInternalViaHttpTest(
       SzAttributeClass attrClass) {
-    this.assumeNativeApiAvailable();
-    Set<String> attrTypes = this.allAttrTypesByClass.get(attrClass);
-    String  uriText = this.formatServerUri(
-        "attribute-types?withInternal=true&attributeClass=" + attrClass);
-    long    before  = System.currentTimeMillis();
-    SzAttributeTypesResponse response
-        = this.invokeServerViaHttp(GET, uriText, SzAttributeTypesResponse.class);
-    long after = System.currentTimeMillis();
+    this.performTest(() -> {
+      Set<String> attrTypes = this.allAttrTypesByClass.get(attrClass);
+      String  uriText = this.formatServerUri(
+          "attribute-types?withInternal=true&attributeClass=" + attrClass);
+      long    before  = System.currentTimeMillis();
+      SzAttributeTypesResponse response
+          = this.invokeServerViaHttp(GET, uriText, SzAttributeTypesResponse.class);
+      long after = System.currentTimeMillis();
 
-    this.validateAttributeTypesResponse(response,
-                                        uriText,
-                                        before,
-                                        after,
-                                        null,
-                                        attrTypes);
+      this.validateAttributeTypesResponse(response,
+                                          uriText,
+                                          before,
+                                          after,
+                                          null,
+                                          attrTypes);
+    });
   }
 
   private Set<String> allFeatureTypes() {
@@ -597,77 +609,78 @@ public class ConfigServicesTest extends AbstractServiceTest
   @ParameterizedTest
   @MethodSource("standardFeatureTypes")
   public void getAttributeTypesForFeatureTest(String featureType) {
-    this.assumeNativeApiAvailable();
-    Set<String> attrTypes = this.standardAttrTypesByFeature.get(featureType);
-    String  uriText = this.formatServerUri(
-        "attribute-types?featureType=" + featureType);
-    UriInfo uriInfo = this.newProxyUriInfo(uriText);
+    this.performTest(() -> {
+      Set<String> attrTypes = this.standardAttrTypesByFeature.get(featureType);
+      String  uriText = this.formatServerUri(
+          "attribute-types?featureType=" + featureType);
+      UriInfo uriInfo = this.newProxyUriInfo(uriText);
 
-    long before = System.currentTimeMillis();
-    SzAttributeTypesResponse response
-        = this.configServices.getAttributeTypes(false,
-                                                null,
-                                                featureType,
-                                                false,
-                                                uriInfo);
-    response.concludeTimers();
-    long after = System.currentTimeMillis();
+      long before = System.currentTimeMillis();
+      SzAttributeTypesResponse response
+          = this.configServices.getAttributeTypes(false,
+                                                  null,
+                                                  featureType,
+                                                  false,
+                                                  uriInfo);
+      response.concludeTimers();
+      long after = System.currentTimeMillis();
 
-    this.validateAttributeTypesResponse(response,
-                                        uriText,
-                                        before,
-                                        after,
-                                        null,
-                                        attrTypes);
-
+      this.validateAttributeTypesResponse(response,
+                                          uriText,
+                                          before,
+                                          after,
+                                          null,
+                                          attrTypes);
+    });
   }
 
   @ParameterizedTest
   @MethodSource("standardFeatureTypes")
   public void getAttributeTypesForFeatureViaHttpTest(String featureType) {
-    this.assumeNativeApiAvailable();
-    Set<String> attrTypes = this.standardAttrTypesByFeature.get(featureType);
-    String  uriText = this.formatServerUri(
-        "attribute-types?featureType=" + featureType);
-    long    before  = System.currentTimeMillis();
-    SzAttributeTypesResponse response
-        = this.invokeServerViaHttp(GET, uriText, SzAttributeTypesResponse.class);
-    long after = System.currentTimeMillis();
+    this.performTest(() -> {
+      Set<String> attrTypes = this.standardAttrTypesByFeature.get(featureType);
+      String  uriText = this.formatServerUri(
+          "attribute-types?featureType=" + featureType);
+      long    before  = System.currentTimeMillis();
+      SzAttributeTypesResponse response
+          = this.invokeServerViaHttp(GET, uriText, SzAttributeTypesResponse.class);
+      long after = System.currentTimeMillis();
 
-    this.validateAttributeTypesResponse(response,
-                                        uriText,
-                                        before,
-                                        after,
-                                        null,
-                                        attrTypes);
+      this.validateAttributeTypesResponse(response,
+                                          uriText,
+                                          before,
+                                          after,
+                                          null,
+                                          attrTypes);
+    });
   }
 
   @ParameterizedTest
   @MethodSource("allFeatureTypes")
   public void getAttributeTypesForFeatureWithInternalTest(String featureType) {
-    this.assumeNativeApiAvailable();
-    Set<String> attrTypes = this.allAttrTypesByFeature.get(featureType);
-    String  uriText = this.formatServerUri(
-        "attribute-types?withInternal=true&featureType=" + featureType);
-    UriInfo uriInfo = this.newProxyUriInfo(uriText);
+    this.performTest(() -> {
+      Set<String> attrTypes = this.allAttrTypesByFeature.get(featureType);
+      String  uriText = this.formatServerUri(
+          "attribute-types?withInternal=true&featureType=" + featureType);
+      UriInfo uriInfo = this.newProxyUriInfo(uriText);
 
-    long before = System.currentTimeMillis();
-    SzAttributeTypesResponse response
-        = this.configServices.getAttributeTypes(true,
-                                                null,
-                                                featureType,
-                                                false,
-                                                uriInfo);
-    response.concludeTimers();
-    long after = System.currentTimeMillis();
+      long before = System.currentTimeMillis();
+      SzAttributeTypesResponse response
+          = this.configServices.getAttributeTypes(true,
+                                                  null,
+                                                  featureType,
+                                                  false,
+                                                  uriInfo);
+      response.concludeTimers();
+      long after = System.currentTimeMillis();
 
-    this.validateAttributeTypesResponse(response,
-                                        uriText,
-                                        before,
-                                        after,
-                                        null,
-                                        attrTypes);
-
+      this.validateAttributeTypesResponse(response,
+                                          uriText,
+                                          before,
+                                          after,
+                                          null,
+                                          attrTypes);
+    });
   }
 
   @ParameterizedTest
@@ -675,21 +688,22 @@ public class ConfigServicesTest extends AbstractServiceTest
   public void getAttributeTypesForFeatureWithInternalViaHttpTest(
       String featureType)
   {
-    this.assumeNativeApiAvailable();
-    Set<String> attrTypes = this.allAttrTypesByFeature.get(featureType);
-    String  uriText = this.formatServerUri(
-        "attribute-types?withInternal=true&featureType=" + featureType);
-    long    before  = System.currentTimeMillis();
-    SzAttributeTypesResponse response
-        = this.invokeServerViaHttp(GET, uriText, SzAttributeTypesResponse.class);
-    long after = System.currentTimeMillis();
+    this.performTest(() -> {
+      Set<String> attrTypes = this.allAttrTypesByFeature.get(featureType);
+      String  uriText = this.formatServerUri(
+          "attribute-types?withInternal=true&featureType=" + featureType);
+      long    before  = System.currentTimeMillis();
+      SzAttributeTypesResponse response
+          = this.invokeServerViaHttp(GET, uriText, SzAttributeTypesResponse.class);
+      long after = System.currentTimeMillis();
 
-    this.validateAttributeTypesResponse(response,
-                                        uriText,
-                                        before,
-                                        after,
-                                        null,
-                                        attrTypes);
+      this.validateAttributeTypesResponse(response,
+                                          uriText,
+                                          before,
+                                          after,
+                                          null,
+                                          attrTypes);
+    });
   }
 
 
@@ -700,185 +714,193 @@ public class ConfigServicesTest extends AbstractServiceTest
   @ParameterizedTest
   @MethodSource("allAttributeCodes")
   public void getAttributeTypeTest(String attrCode) {
-    this.assumeNativeApiAvailable();
-    String  uriText = this.formatServerUri(
-        "attribute-types/" + attrCode);
-    UriInfo uriInfo = this.newProxyUriInfo(uriText);
+    this.performTest(() -> {
+      String  uriText = this.formatServerUri(
+          "attribute-types/" + attrCode);
+      UriInfo uriInfo = this.newProxyUriInfo(uriText);
 
-    long before = System.currentTimeMillis();
-    SzAttributeTypeResponse response
-        = this.configServices.getAttributeType(attrCode, false, uriInfo);
-    response.concludeTimers();
-    long after = System.currentTimeMillis();
+      long before = System.currentTimeMillis();
+      SzAttributeTypeResponse response
+          = this.configServices.getAttributeType(attrCode, false, uriInfo);
+      response.concludeTimers();
+      long after = System.currentTimeMillis();
 
-    this.validateAttributeTypeResponse(response,
-                                       attrCode,
-                                       before,
-                                       after,
-                                       null);
-
+      this.validateAttributeTypeResponse(response,
+                                         attrCode,
+                                         before,
+                                         after,
+                                         null);
+    });
   }
 
   @ParameterizedTest
   @MethodSource("allAttributeCodes")
   public void getAttributeTypeViaHttpTest(String attrCode) {
-    this.assumeNativeApiAvailable();
-    String  uriText = this.formatServerUri(
-        "attribute-types/" + attrCode);
-    long    before  = System.currentTimeMillis();
-    SzAttributeTypeResponse response
-        = this.invokeServerViaHttp(GET, uriText, SzAttributeTypeResponse.class);
-    long after = System.currentTimeMillis();
+    this.performTest(() -> {
+      String  uriText = this.formatServerUri(
+          "attribute-types/" + attrCode);
+      long    before  = System.currentTimeMillis();
+      SzAttributeTypeResponse response
+          = this.invokeServerViaHttp(GET, uriText, SzAttributeTypeResponse.class);
+      long after = System.currentTimeMillis();
 
-    this.validateAttributeTypeResponse(response,
-                                       attrCode,
-                                       before,
-                                       after,
-                                       null);
+      this.validateAttributeTypeResponse(response,
+                                         attrCode,
+                                         before,
+                                         after,
+                                         null);
+    });
   }
 
   @ParameterizedTest
   @MethodSource("allAttributeCodes")
   public void getAttributeTypeWithoutRawTest(String attrCode) {
-    this.assumeNativeApiAvailable();
-    String  uriText = this.formatServerUri(
-        "attribute-types/" + attrCode + "?withRaw=false");
-    UriInfo uriInfo = this.newProxyUriInfo(uriText);
+    this.performTest(() -> {
+      String  uriText = this.formatServerUri(
+          "attribute-types/" + attrCode + "?withRaw=false");
+      UriInfo uriInfo = this.newProxyUriInfo(uriText);
 
-    long before = System.currentTimeMillis();
-    SzAttributeTypeResponse response
-        = this.configServices.getAttributeType(attrCode, false, uriInfo);
-    response.concludeTimers();
-    long after = System.currentTimeMillis();
+      long before = System.currentTimeMillis();
+      SzAttributeTypeResponse response
+          = this.configServices.getAttributeType(attrCode, false, uriInfo);
+      response.concludeTimers();
+      long after = System.currentTimeMillis();
 
-    this.validateAttributeTypeResponse(response,
-                                       attrCode,
-                                       before,
-                                       after,
-                                       false);
+      this.validateAttributeTypeResponse(response,
+                                         attrCode,
+                                         before,
+                                         after,
+                                         false);
+    });
   }
 
   @ParameterizedTest
   @MethodSource("allAttributeCodes")
   public void getAttributeTypeWithoutRawViaHttpTest(String attrCode) {
-    this.assumeNativeApiAvailable();
-    String  uriText = this.formatServerUri(
-        "attribute-types/" + attrCode + "?withRaw=false");
-    long before  = System.currentTimeMillis();
-    SzAttributeTypeResponse response
-        = this.invokeServerViaHttp(GET, uriText, SzAttributeTypeResponse.class);
-    long after = System.currentTimeMillis();
+    this.performTest(() -> {
+      String  uriText = this.formatServerUri(
+          "attribute-types/" + attrCode + "?withRaw=false");
+      long before  = System.currentTimeMillis();
+      SzAttributeTypeResponse response
+          = this.invokeServerViaHttp(GET, uriText, SzAttributeTypeResponse.class);
+      long after = System.currentTimeMillis();
 
-    this.validateAttributeTypeResponse(response,
-                                       attrCode,
-                                       before,
-                                       after,
-                                       false);
+      this.validateAttributeTypeResponse(response,
+                                         attrCode,
+                                         before,
+                                         after,
+                                         false);
+    });
   }
 
   @ParameterizedTest
   @MethodSource("allAttributeCodes")
   public void getAttributeTypeWithRawTest(String attrCode) {
-    this.assumeNativeApiAvailable();
-    String  uriText = this.formatServerUri(
-        "attribute-types/" + attrCode + "?withRaw=true");
-    UriInfo uriInfo = this.newProxyUriInfo(uriText);
+    this.performTest(() -> {
+      String  uriText = this.formatServerUri(
+          "attribute-types/" + attrCode + "?withRaw=true");
+      UriInfo uriInfo = this.newProxyUriInfo(uriText);
 
-    long before = System.currentTimeMillis();
-    SzAttributeTypeResponse response
-        = this.configServices.getAttributeType(attrCode, true, uriInfo);
-    response.concludeTimers();
-    long after = System.currentTimeMillis();
+      long before = System.currentTimeMillis();
+      SzAttributeTypeResponse response
+          = this.configServices.getAttributeType(attrCode, true, uriInfo);
+      response.concludeTimers();
+      long after = System.currentTimeMillis();
 
-    this.validateAttributeTypeResponse(response,
-                                       attrCode,
-                                       before,
-                                       after,
-                                       true);
-
+      this.validateAttributeTypeResponse(response,
+                                         attrCode,
+                                         before,
+                                         after,
+                                         true);
+    });
   }
 
   @ParameterizedTest
   @MethodSource("allAttributeCodes")
   public void getAttributeTypeWithRawViaHttpTest(String attrCode) {
-    this.assumeNativeApiAvailable();
-    String  uriText = this.formatServerUri(
-        "attribute-types/" + attrCode + "?withRaw=true");
-    long before  = System.currentTimeMillis();
-    SzAttributeTypeResponse response
-        = this.invokeServerViaHttp(GET, uriText, SzAttributeTypeResponse.class);
-    long after = System.currentTimeMillis();
+    this.performTest(() -> {
+      String  uriText = this.formatServerUri(
+          "attribute-types/" + attrCode + "?withRaw=true");
+      long before  = System.currentTimeMillis();
+      SzAttributeTypeResponse response
+          = this.invokeServerViaHttp(GET, uriText, SzAttributeTypeResponse.class);
+      long after = System.currentTimeMillis();
 
-    this.validateAttributeTypeResponse(response,
-                                       attrCode,
-                                       before,
-                                       after,
-                                       true);
+      this.validateAttributeTypeResponse(response,
+                                         attrCode,
+                                         before,
+                                         after,
+                                         true);
+    });
   }
 
   @Test public void getCurrentConfigTest() {
-    this.assumeNativeApiAvailable();
-    String  uriText = this.formatServerUri("config/current");
-    UriInfo uriInfo = this.newProxyUriInfo(uriText);
+    this.performTest(() -> {
+      String  uriText = this.formatServerUri("config/current");
+      UriInfo uriInfo = this.newProxyUriInfo(uriText);
 
-    long before = System.currentTimeMillis();
-    SzConfigResponse response
-        = this.configServices.getCurrentConfig(uriInfo);
-    response.concludeTimers();
-    long after = System.currentTimeMillis();
+      long before = System.currentTimeMillis();
+      SzConfigResponse response
+          = this.configServices.getCurrentConfig(uriInfo);
+      response.concludeTimers();
+      long after = System.currentTimeMillis();
 
-    this.validateConfigResponse(response,
-                                uriText,
-                                before,
-                                after,
-                                EXPECTED_DATA_SOURCES);
+      this.validateConfigResponse(response,
+                                  uriText,
+                                  before,
+                                  after,
+                                  EXPECTED_DATA_SOURCES);
+    });
   }
 
   @Test public void getCurrentConfigViaHttpTest() {
-    this.assumeNativeApiAvailable();
-    String  uriText = this.formatServerUri("config/current");
-    long    before  = System.currentTimeMillis();
-    SzConfigResponse response
-        = this.invokeServerViaHttp(GET, uriText, SzConfigResponse.class);
-    long after = System.currentTimeMillis();
+    this.performTest(() -> {
+      String  uriText = this.formatServerUri("config/current");
+      long    before  = System.currentTimeMillis();
+      SzConfigResponse response
+          = this.invokeServerViaHttp(GET, uriText, SzConfigResponse.class);
+      long after = System.currentTimeMillis();
 
-    this.validateConfigResponse(response,
-                                uriText,
-                                before,
-                                after,
-                                EXPECTED_DATA_SOURCES);
+      this.validateConfigResponse(response,
+                                  uriText,
+                                  before,
+                                  after,
+                                  EXPECTED_DATA_SOURCES);
+    });
   }
 
   @Test public void getDefaultConfigTest() {
-    this.assumeNativeApiAvailable();
-    String  uriText = this.formatServerUri("config/default");
-    UriInfo uriInfo = this.newProxyUriInfo(uriText);
+    this.performTest(() -> {
+      String  uriText = this.formatServerUri("config/default");
+      UriInfo uriInfo = this.newProxyUriInfo(uriText);
 
-    long before = System.currentTimeMillis();
-    SzConfigResponse response
-        = this.configServices.getDefaultConfig(uriInfo);
-    response.concludeTimers();
-    long after = System.currentTimeMillis();
+      long before = System.currentTimeMillis();
+      SzConfigResponse response
+          = this.configServices.getDefaultConfig(uriInfo);
+      response.concludeTimers();
+      long after = System.currentTimeMillis();
 
-    this.validateConfigResponse(response,
-                                uriText,
-                                before,
-                                after,
-                                DEFAULT_DATA_SOURCES);
+      this.validateConfigResponse(response,
+                                  uriText,
+                                  before,
+                                  after,
+                                  DEFAULT_DATA_SOURCES);
+    });
   }
 
   @Test public void getDefaultConfigViaHttpTest() {
-    this.assumeNativeApiAvailable();
-    String  uriText = this.formatServerUri("config/default");
-    long    before  = System.currentTimeMillis();
-    SzConfigResponse response
-        = this.invokeServerViaHttp(GET, uriText, SzConfigResponse.class);
-    long after = System.currentTimeMillis();
+    this.performTest(() -> {
+      String  uriText = this.formatServerUri("config/default");
+      long    before  = System.currentTimeMillis();
+      SzConfigResponse response
+          = this.invokeServerViaHttp(GET, uriText, SzConfigResponse.class);
+      long after = System.currentTimeMillis();
 
-    this.validateConfigResponse(response,
-                                uriText,
-                                before,
-                                after,
-                                DEFAULT_DATA_SOURCES);
+      this.validateConfigResponse(response,
+                                  uriText,
+                                  before,
+                                  after,
+                                  DEFAULT_DATA_SOURCES);
+    });
   }
 }

--- a/src/test/java/com/senzing/api/services/ConfigServicesTest.java
+++ b/src/test/java/com/senzing/api/services/ConfigServicesTest.java
@@ -215,7 +215,7 @@ public class ConfigServicesTest extends AbstractServiceTest
   }
 
   @AfterAll public void teardownEnvironment() {
-    this.teardownTestEnvironment(true);
+    this.teardownTestEnvironment();
   }
 
   @Test public void getDataSourcesTest() {

--- a/src/test/java/com/senzing/api/services/EntityDataReadServicesTest.java
+++ b/src/test/java/com/senzing/api/services/EntityDataReadServicesTest.java
@@ -17,7 +17,6 @@ import javax.json.JsonObjectBuilder;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.core.UriInfo;
 import java.io.*;
-import java.net.URLEncoder;
 import java.util.*;
 
 import static com.senzing.api.model.SzHttpMethod.GET;
@@ -204,262 +203,270 @@ public class EntityDataReadServicesTest extends AbstractServiceTest {
 
   @AfterAll
   public void teardownEnvironment() {
-    this.teardownTestEnvironment(true);
+    this.teardownTestEnvironment();
   }
 
   @Test
   public void getRecordTest() {
-    final String dataSource = ABC123.getDataSourceCode();
-    final String recordId = ABC123.getRecordId();
+    this.performTest(() -> {
+      final String dataSource = ABC123.getDataSourceCode();
+      final String recordId = ABC123.getRecordId();
 
-    this.assumeNativeApiAvailable();
-    String uriText = this.formatServerUri(
-        "data-sources/" + dataSource + "/records/" + recordId);
-    UriInfo uriInfo = this.newProxyUriInfo(uriText);
-    long before = System.currentTimeMillis();
-    SzRecordResponse response = this.entityDataServices.getRecord(
-        dataSource, recordId, false, uriInfo);
-    response.concludeTimers();
-    long after = System.currentTimeMillis();
+      String uriText = this.formatServerUri(
+          "data-sources/" + dataSource + "/records/" + recordId);
+      UriInfo uriInfo = this.newProxyUriInfo(uriText);
+      long before = System.currentTimeMillis();
+      SzRecordResponse response = this.entityDataServices.getRecord(
+          dataSource, recordId, false, uriInfo);
+      response.concludeTimers();
+      long after = System.currentTimeMillis();
 
-    this.validateRecordResponse(
-        response,
-        dataSource,
-        recordId,
-        Collections.singleton("Schmoe Joe"),
-        Collections.singleton("101 Main Street, Las Vegas, NV 89101"),
-        Collections.singleton("702-555-1212"),
-        null,
-        Collections.singleton("DOB: 12-JAN-1981"),
-        null,
-        null,
-        before,
-        after,
-        null);
+      this.validateRecordResponse(
+          response,
+          dataSource,
+          recordId,
+          Collections.singleton("Schmoe Joe"),
+          Collections.singleton("101 Main Street, Las Vegas, NV 89101"),
+          Collections.singleton("702-555-1212"),
+          null,
+          Collections.singleton("DOB: 12-JAN-1981"),
+          null,
+          null,
+          before,
+          after,
+          null);
+    });
   }
 
   @Test
   public void getRecordTestViaHttp() {
-    final String dataSource = DEF456.getDataSourceCode();
-    final String recordId = DEF456.getRecordId();
+    this.performTest(() -> {
+      final String dataSource = DEF456.getDataSourceCode();
+      final String recordId = DEF456.getRecordId();
 
-    this.assumeNativeApiAvailable();
-    String uriText = this.formatServerUri(
-        "data-sources/" + dataSource + "/records/" + recordId);
+      String uriText = this.formatServerUri(
+          "data-sources/" + dataSource + "/records/" + recordId);
 
-    long before = System.currentTimeMillis();
-    SzRecordResponse response = this.invokeServerViaHttp(
-        GET, uriText, SzRecordResponse.class);
-    response.concludeTimers();
-    long after = System.currentTimeMillis();
+      long before = System.currentTimeMillis();
+      SzRecordResponse response = this.invokeServerViaHttp(
+          GET, uriText, SzRecordResponse.class);
+      response.concludeTimers();
+      long after = System.currentTimeMillis();
 
-    this.validateRecordResponse(
-        response,
-        dataSource,
-        recordId,
-        Collections.singleton("Smith Joanne"),
-        Collections.singleton("101 Fifth Ave, Las Vegas, NV 10018"),
-        Collections.singleton("212-555-1212"),
-        null,
-        Collections.singleton("DOB: 15-MAY-1983"),
-        null,
-        null,
-        before,
-        after,
-        null);
+      this.validateRecordResponse(
+          response,
+          dataSource,
+          recordId,
+          Collections.singleton("Smith Joanne"),
+          Collections.singleton("101 Fifth Ave, Las Vegas, NV 10018"),
+          Collections.singleton("212-555-1212"),
+          null,
+          Collections.singleton("DOB: 15-MAY-1983"),
+          null,
+          null,
+          before,
+          after,
+          null);
+    });
   }
 
   @Test
   public void getRecordWithRawTest() {
-    final String dataSource = GHI789.getDataSourceCode();
-    final String recordId = GHI789.getRecordId();
+    this.performTest(() -> {
+      final String dataSource = GHI789.getDataSourceCode();
+      final String recordId = GHI789.getRecordId();
 
-    this.assumeNativeApiAvailable();
-    String uriText = this.formatServerUri(
-        "data-sources/" + dataSource + "/records/" + recordId
-            + "?withRaw=true");
-    UriInfo uriInfo = this.newProxyUriInfo(uriText);
-    long before = System.currentTimeMillis();
-    SzRecordResponse response = this.entityDataServices.getRecord(
-        dataSource, recordId, true, uriInfo);
-    response.concludeTimers();
-    long after = System.currentTimeMillis();
+      String uriText = this.formatServerUri(
+          "data-sources/" + dataSource + "/records/" + recordId
+              + "?withRaw=true");
+      UriInfo uriInfo = this.newProxyUriInfo(uriText);
+      long before = System.currentTimeMillis();
+      SzRecordResponse response = this.entityDataServices.getRecord(
+          dataSource, recordId, true, uriInfo);
+      response.concludeTimers();
+      long after = System.currentTimeMillis();
 
-    this.validateRecordResponse(
-        response,
-        dataSource,
-        recordId,
-        Collections.singleton("Doe John"),
-        Collections.singleton("100 Main Street, Los Angeles, CA 90012"),
-        Collections.singleton("818-555-1313"),
-        null,
-        Collections.singleton("DOB: 17-OCT-1978"),
-        null,
-        null,
-        before,
-        after,
-        true);
+      this.validateRecordResponse(
+          response,
+          dataSource,
+          recordId,
+          Collections.singleton("Doe John"),
+          Collections.singleton("100 Main Street, Los Angeles, CA 90012"),
+          Collections.singleton("818-555-1313"),
+          null,
+          Collections.singleton("DOB: 17-OCT-1978"),
+          null,
+          null,
+          before,
+          after,
+          true);
+    });
   }
 
   @Test
   public void getRecordWithRawTestViaHttp() {
-    final String dataSource = JKL012.getDataSourceCode();
-    final String recordId = JKL012.getRecordId();
+    this.performTest(() -> {
+      final String dataSource = JKL012.getDataSourceCode();
+      final String recordId = JKL012.getRecordId();
 
-    this.assumeNativeApiAvailable();
-    String uriText = this.formatServerUri(
-        "data-sources/" + dataSource + "/records/" + recordId
-            + "?withRaw=true");
+      String uriText = this.formatServerUri(
+          "data-sources/" + dataSource + "/records/" + recordId
+              + "?withRaw=true");
 
-    long before = System.currentTimeMillis();
-    SzRecordResponse response = this.invokeServerViaHttp(
-        GET, uriText, SzRecordResponse.class);
-    response.concludeTimers();
-    long after = System.currentTimeMillis();
+      long before = System.currentTimeMillis();
+      SzRecordResponse response = this.invokeServerViaHttp(
+          GET, uriText, SzRecordResponse.class);
+      response.concludeTimers();
+      long after = System.currentTimeMillis();
 
-    this.validateRecordResponse(
-        response,
-        dataSource,
-        recordId,
-        Collections.singleton("Doe Jane"),
-        Collections.singleton("100 Main Street, Los Angeles, CA 90012"),
-        Collections.singleton("818-555-1212"),
-        null,
-        Collections.singleton("DOB: 5-FEB-1979"),
-        null,
-        null,
-        before,
-        after,
-        true);
+      this.validateRecordResponse(
+          response,
+          dataSource,
+          recordId,
+          Collections.singleton("Doe Jane"),
+          Collections.singleton("100 Main Street, Los Angeles, CA 90012"),
+          Collections.singleton("818-555-1212"),
+          null,
+          Collections.singleton("DOB: 5-FEB-1979"),
+          null,
+          null,
+          before,
+          after,
+          true);
+    });
   }
 
   @Test
   public void getRecordWithoutRawTest() {
-    final String dataSource = MNO345.getDataSourceCode();
-    final String recordId = MNO345.getRecordId();
+    this.performTest(() -> {
+      final String dataSource = MNO345.getDataSourceCode();
+      final String recordId = MNO345.getRecordId();
 
-    this.assumeNativeApiAvailable();
-    String uriText = this.formatServerUri(
-        "data-sources/" + dataSource + "/records/" + recordId
-            + "?withRaw=false");
-    UriInfo uriInfo = this.newProxyUriInfo(uriText);
-    long before = System.currentTimeMillis();
-    SzRecordResponse response = this.entityDataServices.getRecord(
-        dataSource, recordId, false, uriInfo);
-    response.concludeTimers();
-    long after = System.currentTimeMillis();
+      String uriText = this.formatServerUri(
+          "data-sources/" + dataSource + "/records/" + recordId
+              + "?withRaw=false");
+      UriInfo uriInfo = this.newProxyUriInfo(uriText);
+      long before = System.currentTimeMillis();
+      SzRecordResponse response = this.entityDataServices.getRecord(
+          dataSource, recordId, false, uriInfo);
+      response.concludeTimers();
+      long after = System.currentTimeMillis();
 
-    this.validateRecordResponse(
-        response,
-        dataSource,
-        recordId,
-        Collections.singleton("Schmoe Joseph"),
-        Collections.singleton("101 Main Street, Las Vegas, NV 89101"),
-        Collections.singleton("702-555-1212"),
-        null,
-        Collections.singleton("DOB: 12-JAN-1981"),
-        null,
-        Collections.singleton("MOTHERS_MAIDEN_NAME: WILSON"),
-        before,
-        after,
-        false);
+      this.validateRecordResponse(
+          response,
+          dataSource,
+          recordId,
+          Collections.singleton("Schmoe Joseph"),
+          Collections.singleton("101 Main Street, Las Vegas, NV 89101"),
+          Collections.singleton("702-555-1212"),
+          null,
+          Collections.singleton("DOB: 12-JAN-1981"),
+          null,
+          Collections.singleton("MOTHERS_MAIDEN_NAME: WILSON"),
+          before,
+          after,
+          false);
+    });
   }
 
   @Test
   public void getRecordWithoutRawTestViaHttp() {
-    final String dataSource = PQR678.getDataSourceCode();
-    final String recordId = PQR678.getRecordId();
+    this.performTest(() -> {
+      final String dataSource = PQR678.getDataSourceCode();
+      final String recordId = PQR678.getRecordId();
 
-    this.assumeNativeApiAvailable();
-    String uriText = this.formatServerUri(
-        "data-sources/" + dataSource + "/records/" + recordId
-            + "?withRaw=false");
+      String uriText = this.formatServerUri(
+          "data-sources/" + dataSource + "/records/" + recordId
+              + "?withRaw=false");
 
-    long before = System.currentTimeMillis();
-    SzRecordResponse response = this.invokeServerViaHttp(
-        GET, uriText, SzRecordResponse.class);
-    response.concludeTimers();
-    long after = System.currentTimeMillis();
+      long before = System.currentTimeMillis();
+      SzRecordResponse response = this.invokeServerViaHttp(
+          GET, uriText, SzRecordResponse.class);
+      response.concludeTimers();
+      long after = System.currentTimeMillis();
 
-    this.validateRecordResponse(
-        response,
-        dataSource,
-        recordId,
-        Collections.singleton("Smith Jo Anne"),
-        Collections.singleton("101 Fifth Ave, Las Vegas, NV 10018"),
-        Collections.singleton("212-555-1212"),
-        null,
-        Collections.singleton("DOB: 15-MAY-1983"),
-        null,
-        Collections.singleton("MOTHERS_MAIDEN_NAME: JACOBS"),
-        before,
-        after,
-        false);
+      this.validateRecordResponse(
+          response,
+          dataSource,
+          recordId,
+          Collections.singleton("Smith Jo Anne"),
+          Collections.singleton("101 Fifth Ave, Las Vegas, NV 10018"),
+          Collections.singleton("212-555-1212"),
+          null,
+          Collections.singleton("DOB: 15-MAY-1983"),
+          null,
+          Collections.singleton("MOTHERS_MAIDEN_NAME: JACOBS"),
+          before,
+          after,
+          false);
+    });
   }
 
 
   @Test
   public void getRelatedRecordTest() {
-    final String dataSource = BCD123.getDataSourceCode();
-    final String recordId = BCD123.getRecordId();
-    final String relKey = relationshipKey(BCD123, CDE456);
+    this.performTest(() -> {
+      final String dataSource = BCD123.getDataSourceCode();
+      final String recordId = BCD123.getRecordId();
+      final String relKey = relationshipKey(BCD123, CDE456);
 
-    this.assumeNativeApiAvailable();
-    String uriText = this.formatServerUri(
-        "data-sources/" + dataSource + "/records/" + recordId);
-    UriInfo uriInfo = this.newProxyUriInfo(uriText);
-    long before = System.currentTimeMillis();
-    SzRecordResponse response = this.entityDataServices.getRecord(
-        dataSource, recordId, false, uriInfo);
-    response.concludeTimers();
-    long after = System.currentTimeMillis();
+      String uriText = this.formatServerUri(
+          "data-sources/" + dataSource + "/records/" + recordId);
+      UriInfo uriInfo = this.newProxyUriInfo(uriText);
+      long before = System.currentTimeMillis();
+      SzRecordResponse response = this.entityDataServices.getRecord(
+          dataSource, recordId, false, uriInfo);
+      response.concludeTimers();
+      long after = System.currentTimeMillis();
 
-    this.validateRecordResponse(
-        response,
-        dataSource,
-        recordId,
-        set("Bruce Wayne", "AKA: Batman"),
-        Collections.singleton("101 Wayne Manor Rd; Gotham City, NJ 07017"),
-        Collections.singleton("201-765-3451"),
-        null,
-        set("DOB: 08-SEP-1971", "GENDER: M"),
-        Collections.singleton("REL_LINK: HUSBAND: SPOUSE " + relKey),
-        null,
-        before,
-        after,
-        null);
+      this.validateRecordResponse(
+          response,
+          dataSource,
+          recordId,
+          set("Bruce Wayne", "AKA: Batman"),
+          Collections.singleton("101 Wayne Manor Rd; Gotham City, NJ 07017"),
+          Collections.singleton("201-765-3451"),
+          null,
+          set("DOB: 08-SEP-1971", "GENDER: M"),
+          Collections.singleton("REL_LINK: HUSBAND: SPOUSE " + relKey),
+          null,
+          before,
+          after,
+          null);
+    });
   }
 
   @Test
   public void getRelatedRecordTestViaHttp() {
-    final String dataSource = CDE456.getDataSourceCode();
-    final String recordId = CDE456.getRecordId();
-    final String relKey = relationshipKey(BCD123, CDE456);
+    this.performTest(() -> {
+      final String dataSource = CDE456.getDataSourceCode();
+      final String recordId = CDE456.getRecordId();
+      final String relKey = relationshipKey(BCD123, CDE456);
 
-    this.assumeNativeApiAvailable();
-    String uriText = this.formatServerUri(
-        "data-sources/" + dataSource + "/records/" + recordId);
+      String uriText = this.formatServerUri(
+          "data-sources/" + dataSource + "/records/" + recordId);
 
-    long before = System.currentTimeMillis();
-    SzRecordResponse response = this.invokeServerViaHttp(
-        GET, uriText, SzRecordResponse.class);
-    response.concludeTimers();
-    long after = System.currentTimeMillis();
+      long before = System.currentTimeMillis();
+      SzRecordResponse response = this.invokeServerViaHttp(
+          GET, uriText, SzRecordResponse.class);
+      response.concludeTimers();
+      long after = System.currentTimeMillis();
 
-    this.validateRecordResponse(
-        response,
-        dataSource,
-        recordId,
-        set("Selina Kyle", "AKA: Catwoman"),
-        Collections.singleton("101 Wayne Manor Rd; Gotham City, NJ 07017"),
-        Collections.singleton("201-875-2314"),
-        null,
-        set("DOB: 05-DEC-1981", "GENDER: F"),
-        Collections.singleton("REL_LINK: WIFE: SPOUSE " + relKey),
-        null,
-        before,
-        after,
-        null);
+      this.validateRecordResponse(
+          response,
+          dataSource,
+          recordId,
+          set("Selina Kyle", "AKA: Catwoman"),
+          Collections.singleton("101 Wayne Manor Rd; Gotham City, NJ 07017"),
+          Collections.singleton("201-875-2314"),
+          null,
+          set("DOB: 05-DEC-1981", "GENDER: F"),
+          Collections.singleton("REL_LINK: WIFE: SPOUSE " + relKey),
+          null,
+          before,
+          after,
+          null);
+    });
   }
 
   private Long getEntityIdForRecordId(SzRecordId recordId) {
@@ -980,52 +987,53 @@ public class EntityDataReadServicesTest extends AbstractServiceTest {
       Map<SzAttributeClass, Set<String>>  expectedDataValues,
       Set<String>                         expectedOtherDataValues)
   {
-    String testInfo = "keyRecord=[ " + keyRecordId
-        + " ], forceMinimal=[ " + forceMinimal
-        + " ], featureMode=[ " + featureMode
-        + " ], withRelated=[ " + withRelated
-        + " ], withRaw=[ " + withRaw + " ]";
+    this.performTest(() -> {
+      String testInfo = "keyRecord=[ " + keyRecordId
+          + " ], forceMinimal=[ " + forceMinimal
+          + " ], featureMode=[ " + featureMode
+          + " ], withRelated=[ " + withRelated
+          + " ], withRaw=[ " + withRaw + " ]";
 
-    this.assumeNativeApiAvailable();
-    StringBuilder sb = new StringBuilder();
-    sb.append("data-sources/").append(keyRecordId.getDataSourceCode());
-    sb.append("/records/").append(keyRecordId.getRecordId()).append("/entity");
-    buildEntityQueryString(sb, withRaw, withRelated, forceMinimal, featureMode);
+      StringBuilder sb = new StringBuilder();
+      sb.append("data-sources/").append(keyRecordId.getDataSourceCode());
+      sb.append("/records/").append(keyRecordId.getRecordId()).append("/entity");
+      buildEntityQueryString(sb, withRaw, withRelated, forceMinimal, featureMode);
 
-    String uriText = this.formatServerUri(sb.toString());
-    UriInfo uriInfo = this.newProxyUriInfo(uriText);
+      String uriText = this.formatServerUri(sb.toString());
+      UriInfo uriInfo = this.newProxyUriInfo(uriText);
 
-    long before = System.currentTimeMillis();
+      long before = System.currentTimeMillis();
 
-    SzEntityResponse response = this.entityDataServices.getEntityByRecordId(
-        keyRecordId.getDataSourceCode(),
-        keyRecordId.getRecordId(),
-        (withRaw != null ? withRaw : false),
-        (withRelated != null ? withRelated : false),
-        (forceMinimal != null ? forceMinimal : false),
-        (featureMode != null ? featureMode : WITH_DUPLICATES),
-        uriInfo);
+      SzEntityResponse response = this.entityDataServices.getEntityByRecordId(
+          keyRecordId.getDataSourceCode(),
+          keyRecordId.getRecordId(),
+          (withRaw != null ? withRaw : false),
+          (withRelated != null ? withRelated : false),
+          (forceMinimal != null ? forceMinimal : false),
+          (featureMode != null ? featureMode : WITH_DUPLICATES),
+          uriInfo);
 
-    response.concludeTimers();
-    long after = System.currentTimeMillis();
+      response.concludeTimers();
+      long after = System.currentTimeMillis();
 
-    this.validateEntityResponse(testInfo,
-                                response,
-                                uriText,
-                                withRaw,
-                                withRelated,
-                                forceMinimal,
-                                featureMode,
-                                expectedRecordCount,
-                                expectedRecordIds,
-                                relatedEntityCount,
-                                expectedFeatureCounts,
-                                primaryFeatureValues,
-                                duplicateFeatureValues,
-                                expectedDataValues,
-                                expectedOtherDataValues,
-                                before,
-                                after);
+      this.validateEntityResponse(testInfo,
+                                  response,
+                                  uriText,
+                                  withRaw,
+                                  withRelated,
+                                  forceMinimal,
+                                  featureMode,
+                                  expectedRecordCount,
+                                  expectedRecordIds,
+                                  relatedEntityCount,
+                                  expectedFeatureCounts,
+                                  primaryFeatureValues,
+                                  duplicateFeatureValues,
+                                  expectedDataValues,
+                                  expectedOtherDataValues,
+                                  before,
+                                  after);
+    });
   }
 
   @ParameterizedTest
@@ -1045,161 +1053,166 @@ public class EntityDataReadServicesTest extends AbstractServiceTest {
       Map<SzAttributeClass, Set<String>>  expectedDataValues,
       Set<String>                         expectedOtherDataValues)
   {
-    String testInfo = "keyRecord=[ " + keyRecordId
-        + " ], forceMinimal=[ " + forceMinimal
-        + " ], featureMode=[ " + featureMode
-        + " ], withRelated=[ " + withRelated
-        + " ], withRaw=[ " + withRaw + " ]";
-    this.assumeNativeApiAvailable();
+    this.performTest(() -> {
+      String testInfo = "keyRecord=[ " + keyRecordId
+          + " ], forceMinimal=[ " + forceMinimal
+          + " ], featureMode=[ " + featureMode
+          + " ], withRelated=[ " + withRelated
+          + " ], withRaw=[ " + withRaw + " ]";
 
-    StringBuilder sb = new StringBuilder();
-    sb.append("data-sources/").append(keyRecordId.getDataSourceCode());
-    sb.append("/records/").append(keyRecordId.getRecordId()).append("/entity");
-    buildEntityQueryString(sb, withRaw, withRelated, forceMinimal, featureMode);
+      StringBuilder sb = new StringBuilder();
+      sb.append("data-sources/").append(keyRecordId.getDataSourceCode());
+      sb.append("/records/").append(keyRecordId.getRecordId()).append("/entity");
+      buildEntityQueryString(sb, withRaw, withRelated, forceMinimal, featureMode);
 
-    String uriText = this.formatServerUri(sb.toString());
+      String uriText = this.formatServerUri(sb.toString());
 
-    long before = System.currentTimeMillis();
-    SzEntityResponse response = this.invokeServerViaHttp(
-        GET, uriText, SzEntityResponse.class);
-    response.concludeTimers();
-    long after = System.currentTimeMillis();
+      long before = System.currentTimeMillis();
+      SzEntityResponse response = this.invokeServerViaHttp(
+          GET, uriText, SzEntityResponse.class);
+      response.concludeTimers();
+      long after = System.currentTimeMillis();
 
-    this.validateEntityResponse(testInfo,
-                                response,
-                                uriText,
-                                withRaw,
-                                withRelated,
-                                forceMinimal,
-                                featureMode,
-                                expectedRecordCount,
-                                expectedRecordIds,
-                                relatedEntityCount,
-                                expectedFeatureCounts,
-                                primaryFeatureValues,
-                                duplicateFeatureValues,
-                                expectedDataValues,
-                                expectedOtherDataValues,
-                                before,
-                                after);
+      this.validateEntityResponse(testInfo,
+                                  response,
+                                  uriText,
+                                  withRaw,
+                                  withRelated,
+                                  forceMinimal,
+                                  featureMode,
+                                  expectedRecordCount,
+                                  expectedRecordIds,
+                                  relatedEntityCount,
+                                  expectedFeatureCounts,
+                                  primaryFeatureValues,
+                                  duplicateFeatureValues,
+                                  expectedDataValues,
+                                  expectedOtherDataValues,
+                                  before,
+                                  after);
+    });
   }
 
   @Test
   public void getNotFoundEntityByBadRecordIdTest()
   {
-    final String badRecordId = "ABC123DEF456GHI789";
-    this.assumeNativeApiAvailable();
-    StringBuilder sb = new StringBuilder();
-    sb.append("data-sources/").append(PASSENGERS);
-    sb.append("/records/").append(badRecordId).append("/entity");
+    this.performTest(() -> {
+      final String badRecordId = "ABC123DEF456GHI789";
+      StringBuilder sb = new StringBuilder();
+      sb.append("data-sources/").append(PASSENGERS);
+      sb.append("/records/").append(badRecordId).append("/entity");
 
-    String uriText = this.formatServerUri(sb.toString());
-    UriInfo uriInfo = this.newProxyUriInfo(uriText);
+      String uriText = this.formatServerUri(sb.toString());
+      UriInfo uriInfo = this.newProxyUriInfo(uriText);
 
-    long before = System.currentTimeMillis();
+      long before = System.currentTimeMillis();
 
-    try {
-      this.entityDataServices.getEntityByRecordId(
-          PASSENGERS,
-          badRecordId,
-          false,
-          false,
-          false,
-          WITH_DUPLICATES,
-          uriInfo);
+      try {
+        this.entityDataServices.getEntityByRecordId(
+            PASSENGERS,
+            badRecordId,
+            false,
+            false,
+            false,
+            WITH_DUPLICATES,
+            uriInfo);
 
-      fail("Expected entity for data source \"" + PASSENGERS
-               + "\" and record ID \"" + badRecordId + "\" to NOT be found");
-    } catch (NotFoundException expected) {
-      SzErrorResponse response
-          = (SzErrorResponse) expected.getResponse().getEntity();
-      response.concludeTimers();
-      long after = System.currentTimeMillis();
+        fail("Expected entity for data source \"" + PASSENGERS
+                 + "\" and record ID \"" + badRecordId + "\" to NOT be found");
+      } catch (NotFoundException expected) {
+        SzErrorResponse response
+            = (SzErrorResponse) expected.getResponse().getEntity();
+        response.concludeTimers();
+        long after = System.currentTimeMillis();
 
-      this.validateBasics(
-          response, 404, GET, uriText, before, after);
-    }
+        this.validateBasics(
+            response, 404, GET, uriText, before, after);
+      }
+    });
   }
 
   @Test
   public void getNotFoundEntityByBadDataSourceTest()
   {
-    final String badDataSource = "FOOBAR";
-    final String badRecordId = "ABC123DEF456GHI789";
-    this.assumeNativeApiAvailable();
-    StringBuilder sb = new StringBuilder();
-    sb.append("data-sources/").append(badDataSource);
-    sb.append("/records/").append(badRecordId).append("/entity");
+    this.performTest(() -> {
+      final String badDataSource = "FOOBAR";
+      final String badRecordId = "ABC123DEF456GHI789";
+      StringBuilder sb = new StringBuilder();
+      sb.append("data-sources/").append(badDataSource);
+      sb.append("/records/").append(badRecordId).append("/entity");
 
-    String uriText = this.formatServerUri(sb.toString());
-    UriInfo uriInfo = this.newProxyUriInfo(uriText);
+      String uriText = this.formatServerUri(sb.toString());
+      UriInfo uriInfo = this.newProxyUriInfo(uriText);
 
-    long before = System.currentTimeMillis();
+      long before = System.currentTimeMillis();
 
-    try {
-      this.entityDataServices.getEntityByRecordId(
-          PASSENGERS,
-          badRecordId,
-          false,
-          false,
-          false,
-          WITH_DUPLICATES,
-          uriInfo);
+      try {
+        this.entityDataServices.getEntityByRecordId(
+            PASSENGERS,
+            badRecordId,
+            false,
+            false,
+            false,
+            WITH_DUPLICATES,
+            uriInfo);
 
-      fail("Expected entity for data source \"" + badDataSource
-               + "\" and record ID \"" + badRecordId + "\" to NOT be found");
-    } catch (NotFoundException expected) {
-      SzErrorResponse response
-          = (SzErrorResponse) expected.getResponse().getEntity();
-      response.concludeTimers();
-      long after = System.currentTimeMillis();
+        fail("Expected entity for data source \"" + badDataSource
+                 + "\" and record ID \"" + badRecordId + "\" to NOT be found");
+      } catch (NotFoundException expected) {
+        SzErrorResponse response
+            = (SzErrorResponse) expected.getResponse().getEntity();
+        response.concludeTimers();
+        long after = System.currentTimeMillis();
 
-      this.validateBasics(
-          response, 404, GET, uriText, before, after);
-    }
+        this.validateBasics(
+            response, 404, GET, uriText, before, after);
+      }
+    });
   }
 
   @Test
   public void getNotFoundEntityByBadRecordIdTestViaHttp()
   {
-    final String badRecordId = "ABC123DEF456GHI789";
-    this.assumeNativeApiAvailable();
-    StringBuilder sb = new StringBuilder();
-    sb.append("data-sources/").append(PASSENGERS);
-    sb.append("/records/").append(badRecordId).append("/entity");
+    this.performTest(() -> {
+      final String badRecordId = "ABC123DEF456GHI789";
+      StringBuilder sb = new StringBuilder();
+      sb.append("data-sources/").append(PASSENGERS);
+      sb.append("/records/").append(badRecordId).append("/entity");
 
-    String uriText = this.formatServerUri(sb.toString());
+      String uriText = this.formatServerUri(sb.toString());
 
-    long before = System.currentTimeMillis();
-    SzErrorResponse response = this.invokeServerViaHttp(
-        GET, uriText, SzErrorResponse.class);
-    response.concludeTimers();
-    long after = System.currentTimeMillis();
+      long before = System.currentTimeMillis();
+      SzErrorResponse response = this.invokeServerViaHttp(
+          GET, uriText, SzErrorResponse.class);
+      response.concludeTimers();
+      long after = System.currentTimeMillis();
 
-    this.validateBasics(
-        response, 404, GET, uriText, before, after);
+      this.validateBasics(
+          response, 404, GET, uriText, before, after);
+    });
   }
 
   @Test
   public void getNotFoundEntityByBadDataSourceTestViaHttp()
   {
-    final String badDataSource = "FOOBAR";
-    final String badRecordId = "ABC123DEF456GHI789";
-    this.assumeNativeApiAvailable();
-    StringBuilder sb = new StringBuilder();
-    sb.append("data-sources/").append(badDataSource);
-    sb.append("/records/").append(badRecordId).append("/entity");
+    this.performTest(() -> {
+      final String badDataSource = "FOOBAR";
+      final String badRecordId = "ABC123DEF456GHI789";
+      StringBuilder sb = new StringBuilder();
+      sb.append("data-sources/").append(badDataSource);
+      sb.append("/records/").append(badRecordId).append("/entity");
 
-    String uriText = this.formatServerUri(sb.toString());
+      String uriText = this.formatServerUri(sb.toString());
 
-    long before = System.currentTimeMillis();
-    SzErrorResponse response = this.invokeServerViaHttp(
-        GET, uriText, SzErrorResponse.class);
-    response.concludeTimers();
-    long after = System.currentTimeMillis();
+      long before = System.currentTimeMillis();
+      SzErrorResponse response = this.invokeServerViaHttp(
+          GET, uriText, SzErrorResponse.class);
+      response.concludeTimers();
+      long after = System.currentTimeMillis();
 
-    this.validateBasics(
-        response, 404, GET, uriText, before, after);
+      this.validateBasics(
+          response, 404, GET, uriText, before, after);
+    });
   }
 
   @ParameterizedTest
@@ -1219,54 +1232,54 @@ public class EntityDataReadServicesTest extends AbstractServiceTest {
       Map<SzAttributeClass, Set<String>>  expectedDataValues,
       Set<String>                         expectedOtherDataValues)
   {
-    String testInfo = "keyRecord=[ " + keyRecordId
-        + " ], forceMinimal=[ " + forceMinimal
-        + " ], featureMode=[ " + featureMode
-        + " ], withRelated=[ " + withRelated
-        + " ], withRaw=[ " + withRaw + " ]";
+    this.performTest(() -> {
+      String testInfo = "keyRecord=[ " + keyRecordId
+          + " ], forceMinimal=[ " + forceMinimal
+          + " ], featureMode=[ " + featureMode
+          + " ], withRelated=[ " + withRelated
+          + " ], withRaw=[ " + withRaw + " ]";
 
-    this.assumeNativeApiAvailable();
+      final Long entityId = this.getEntityIdForRecordId(keyRecordId);
 
-    final Long entityId = this.getEntityIdForRecordId(keyRecordId);
+      StringBuilder sb = new StringBuilder();
+      sb.append("entities/").append(entityId);
+      buildEntityQueryString(sb, withRaw, withRelated, forceMinimal, featureMode);
 
-    StringBuilder sb = new StringBuilder();
-    sb.append("entities/").append(entityId);
-    buildEntityQueryString(sb, withRaw, withRelated, forceMinimal, featureMode);
+      String uriText = this.formatServerUri(sb.toString());
+      UriInfo uriInfo = this.newProxyUriInfo(uriText);
 
-    String uriText = this.formatServerUri(sb.toString());
-    UriInfo uriInfo = this.newProxyUriInfo(uriText);
+      long before = System.currentTimeMillis();
 
-    long before = System.currentTimeMillis();
+      SzEntityResponse response = this.entityDataServices.getEntityByRecordId(
+          keyRecordId.getDataSourceCode(),
+          keyRecordId.getRecordId(),
+          (withRaw != null ? withRaw : false),
+          (withRelated != null ? withRelated : false),
+          (forceMinimal != null ? forceMinimal : false),
+          (featureMode != null ? featureMode : WITH_DUPLICATES),
+          uriInfo);
 
-    SzEntityResponse response = this.entityDataServices.getEntityByRecordId(
-        keyRecordId.getDataSourceCode(),
-        keyRecordId.getRecordId(),
-        (withRaw != null ? withRaw : false),
-        (withRelated != null ? withRelated : false),
-        (forceMinimal != null ? forceMinimal : false),
-        (featureMode != null ? featureMode : WITH_DUPLICATES),
-        uriInfo);
+      response.concludeTimers();
+      long after = System.currentTimeMillis();
 
-    response.concludeTimers();
-    long after = System.currentTimeMillis();
-
-    this.validateEntityResponse(testInfo,
-                                response,
-                                uriText,
-                                withRaw,
-                                withRelated,
-                                forceMinimal,
-                                featureMode,
-                                expectedRecordCount,
-                                expectedRecordIds,
-                                relatedEntityCount,
-                                expectedFeatureCounts,
-                                primaryFeatureValues,
-                                duplicateFeatureValues,
-                                expectedDataValues,
-                                expectedOtherDataValues,
-                                before,
-                                after);
+      this.validateEntityResponse(testInfo,
+                                  response,
+                                  uriText,
+                                  withRaw,
+                                  withRelated,
+                                  forceMinimal,
+                                  featureMode,
+                                  expectedRecordCount,
+                                  expectedRecordIds,
+                                  relatedEntityCount,
+                                  expectedFeatureCounts,
+                                  primaryFeatureValues,
+                                  duplicateFeatureValues,
+                                  expectedDataValues,
+                                  expectedOtherDataValues,
+                                  before,
+                                  after);
+    });
   }
 
   @ParameterizedTest
@@ -1286,99 +1299,101 @@ public class EntityDataReadServicesTest extends AbstractServiceTest {
       Map<SzAttributeClass, Set<String>>  expectedDataValues,
       Set<String>                         expectedOtherDataValues)
   {
-    String testInfo = "keyRecord=[ " + keyRecordId
-        + " ], forceMinimal=[ " + forceMinimal
-        + " ], featureMode=[ " + featureMode
-        + " ], withRelated=[ " + withRelated
-        + " ], withRaw=[ " + withRaw + " ]";
-    this.assumeNativeApiAvailable();
+    this.performTest(() -> {
+      String testInfo = "keyRecord=[ " + keyRecordId
+          + " ], forceMinimal=[ " + forceMinimal
+          + " ], featureMode=[ " + featureMode
+          + " ], withRelated=[ " + withRelated
+          + " ], withRaw=[ " + withRaw + " ]";
 
-    final Long entityId = this.getEntityIdForRecordId(keyRecordId);
+      final Long entityId = this.getEntityIdForRecordId(keyRecordId);
 
-    StringBuilder sb = new StringBuilder();
-    sb.append("entities/").append(entityId);
-    buildEntityQueryString(sb, withRaw, withRelated, forceMinimal, featureMode);
+      StringBuilder sb = new StringBuilder();
+      sb.append("entities/").append(entityId);
+      buildEntityQueryString(sb, withRaw, withRelated, forceMinimal, featureMode);
 
-    String uriText = this.formatServerUri(sb.toString());
+      String uriText = this.formatServerUri(sb.toString());
 
-    long before = System.currentTimeMillis();
-    SzEntityResponse response = this.invokeServerViaHttp(
-        GET, uriText, SzEntityResponse.class);
-    response.concludeTimers();
-    long after = System.currentTimeMillis();
+      long before = System.currentTimeMillis();
+      SzEntityResponse response = this.invokeServerViaHttp(
+          GET, uriText, SzEntityResponse.class);
+      response.concludeTimers();
+      long after = System.currentTimeMillis();
 
-    this.validateEntityResponse(testInfo,
-                                response,
-                                uriText,
-                                withRaw,
-                                withRelated,
-                                forceMinimal,
-                                featureMode,
-                                expectedRecordCount,
-                                expectedRecordIds,
-                                relatedEntityCount,
-                                expectedFeatureCounts,
-                                primaryFeatureValues,
-                                duplicateFeatureValues,
-                                expectedDataValues,
-                                expectedOtherDataValues,
-                                before,
-                                after);
+      this.validateEntityResponse(testInfo,
+                                  response,
+                                  uriText,
+                                  withRaw,
+                                  withRelated,
+                                  forceMinimal,
+                                  featureMode,
+                                  expectedRecordCount,
+                                  expectedRecordIds,
+                                  relatedEntityCount,
+                                  expectedFeatureCounts,
+                                  primaryFeatureValues,
+                                  duplicateFeatureValues,
+                                  expectedDataValues,
+                                  expectedOtherDataValues,
+                                  before,
+                                  after);
+    });
   }
 
 
   @Test
   public void getNotFoundEntityByBadEntityIdTest()
   {
-    final long badEntityId = Long.MAX_VALUE;
-    this.assumeNativeApiAvailable();
+    this.performTest(() -> {
+      final long badEntityId = Long.MAX_VALUE;
 
-    String uriText = this.formatServerUri("entities/" + badEntityId);
-    UriInfo uriInfo = this.newProxyUriInfo(uriText);
+      String uriText = this.formatServerUri("entities/" + badEntityId);
+      UriInfo uriInfo = this.newProxyUriInfo(uriText);
 
-    long before = System.currentTimeMillis();
+      long before = System.currentTimeMillis();
 
-    try {
-      this.entityDataServices.getEntityByEntityId(
-          badEntityId,
-          false,
-          false,
-          false,
-          WITH_DUPLICATES,
-          uriInfo);
+      try {
+        this.entityDataServices.getEntityByEntityId(
+            badEntityId,
+            false,
+            false,
+            false,
+            WITH_DUPLICATES,
+            uriInfo);
 
-      fail("Expected entity for entity ID " + badEntityId + " to NOT be found");
+        fail("Expected entity for entity ID " + badEntityId + " to NOT be found");
 
-    } catch (NotFoundException expected) {
-      SzErrorResponse response
-          = (SzErrorResponse) expected.getResponse().getEntity();
-      response.concludeTimers();
-      long after = System.currentTimeMillis();
+      } catch (NotFoundException expected) {
+        SzErrorResponse response
+            = (SzErrorResponse) expected.getResponse().getEntity();
+        response.concludeTimers();
+        long after = System.currentTimeMillis();
 
-      this.validateBasics(
-          response, 404, GET, uriText, before, after);
-    }
+        this.validateBasics(
+            response, 404, GET, uriText, before, after);
+      }
+    });
   }
 
   @Test
   public void getNotFoundEntityByBadEntityIdTestViaHttp()
   {
-    final long badEntityId = Long.MAX_VALUE;
-    this.assumeNativeApiAvailable();
+    this.performTest(() -> {
+      final long badEntityId = Long.MAX_VALUE;
 
-    String uriText = this.formatServerUri("entities/" + badEntityId);
+      String uriText = this.formatServerUri("entities/" + badEntityId);
 
-    long before = System.currentTimeMillis();
-    SzErrorResponse response = this.invokeServerViaHttp(
-        GET, uriText, SzErrorResponse.class);
-    response.concludeTimers();
-    long after = System.currentTimeMillis();
+      long before = System.currentTimeMillis();
+      SzErrorResponse response = this.invokeServerViaHttp(
+          GET, uriText, SzErrorResponse.class);
+      response.concludeTimers();
+      long after = System.currentTimeMillis();
 
-    this.validateBasics(
-        response, 404, GET, uriText, before, after);
+      this.validateBasics(
+          response, 404, GET, uriText, before, after);
+
+    });
   }
-
-
 
   private static class Criterion {
     private String key;
@@ -1483,72 +1498,74 @@ public class EntityDataReadServicesTest extends AbstractServiceTest {
                                     SzFeatureInclusion featureMode,
                                     Boolean withRelationships,
                                     Boolean withRaw)
-      throws UnsupportedEncodingException {
-    String testInfo = "criteria=[ " + criteria
-        + " ], forceMinimal=[ " + forceMinimal
-        + " ], featureMode=[ " + featureMode
-        + " ], withRelationships=[ " + withRelationships
-        + " ], withRaw=[ " + withRaw + " ]";
+  {
+    this.performTest(() -> {
+      String testInfo = "criteria=[ " + criteria
+          + " ], forceMinimal=[ " + forceMinimal
+          + " ], featureMode=[ " + featureMode
+          + " ], withRelationships=[ " + withRelationships
+          + " ], withRaw=[ " + withRaw + " ]";
 
-    JsonObjectBuilder job = Json.createObjectBuilder();
-    criteria.entrySet().forEach(entry -> {
-      String key = entry.getKey();
-      Set<String> values = entry.getValue();
-      if (values.size() == 1) {
-        job.add(key, values.iterator().next());
-      } else {
-        JsonArrayBuilder jab = Json.createArrayBuilder();
-        for (String value : values) {
-          JsonObjectBuilder job2 = Json.createObjectBuilder();
-          job2.add(key, value);
-          jab.add(job2);
+      JsonObjectBuilder job = Json.createObjectBuilder();
+      criteria.entrySet().forEach(entry -> {
+        String key = entry.getKey();
+        Set<String> values = entry.getValue();
+        if (values.size() == 1) {
+          job.add(key, values.iterator().next());
+        } else {
+          JsonArrayBuilder jab = Json.createArrayBuilder();
+          for (String value : values) {
+            JsonObjectBuilder job2 = Json.createObjectBuilder();
+            job2.add(key, value);
+            jab.add(job2);
+          }
+          job.add(key, jab);
         }
-        job.add(key, jab);
+      });
+      String attrs = JsonUtils.toJsonText(job);
+
+      String uriText = this.formatServerUri(
+          "entities?attrs=" + urlEncode(attrs));
+      if (forceMinimal != null) {
+        uriText += ("&forceMinimal=" + forceMinimal);
       }
+      if (featureMode != null) {
+        uriText += ("&featureMode=" + featureMode);
+      }
+      if (withRelationships != null) {
+        uriText += ("&withRelationships=" + withRelationships);
+      }
+      if (withRaw != null) {
+        uriText += ("&withRaw=" + withRaw);
+      }
+      UriInfo uriInfo = this.newProxyUriInfo(uriText);
+
+      long before = System.currentTimeMillis();
+      SzAttributeSearchResponse response
+          = this.entityDataServices.searchByAttributes(
+          attrs,
+          (forceMinimal != null ? forceMinimal : false),
+          (featureMode != null ? featureMode : WITH_DUPLICATES),
+          (withRelationships != null ? withRelationships : false),
+          (withRaw != null ? withRaw : false),
+          uriInfo);
+
+      response.concludeTimers();
+      long after = System.currentTimeMillis();
+
+      this.validateSearchResponse(
+          testInfo,
+          response,
+          uriText,
+          expectedCount,
+          withRelationships,
+          forceMinimal,
+          featureMode,
+          before,
+          after,
+          withRaw);
+
     });
-    String attrs = JsonUtils.toJsonText(job);
-
-    this.assumeNativeApiAvailable();
-    String uriText = this.formatServerUri(
-        "entities?attrs=" + URLEncoder.encode(attrs, "UTF-8"));
-    if (forceMinimal != null) {
-      uriText += ("&forceMinimal=" + forceMinimal);
-    }
-    if (featureMode != null) {
-      uriText += ("&featureMode=" + featureMode);
-    }
-    if (withRelationships != null) {
-      uriText += ("&withRelationships=" + withRelationships);
-    }
-    if (withRaw != null) {
-      uriText += ("&withRaw=" + withRaw);
-    }
-    UriInfo uriInfo = this.newProxyUriInfo(uriText);
-
-    long before = System.currentTimeMillis();
-    SzAttributeSearchResponse response
-        = this.entityDataServices.searchByAttributes(
-        attrs,
-        (forceMinimal != null ? forceMinimal : false),
-        (featureMode != null ? featureMode : WITH_DUPLICATES),
-        (withRelationships != null ? withRelationships : false),
-        (withRaw != null ? withRaw : false),
-        uriInfo);
-
-    response.concludeTimers();
-    long after = System.currentTimeMillis();
-
-    this.validateSearchResponse(
-        testInfo,
-        response,
-        uriText,
-        expectedCount,
-        withRelationships,
-        forceMinimal,
-        featureMode,
-        before,
-        after,
-        withRaw);
   }
 
   @ParameterizedTest
@@ -1560,65 +1577,66 @@ public class EntityDataReadServicesTest extends AbstractServiceTest {
       SzFeatureInclusion featureMode,
       Boolean withRelationships,
       Boolean withRaw)
-      throws UnsupportedEncodingException {
-    String testInfo = "criteria=[ " + criteria
-        + " ], forceMinimal=[ " + forceMinimal
-        + " ], featureMode=[ " + featureMode
-        + " ], withRelationships=[ " + withRelationships
-        + " ], withRaw=[ " + withRaw + " ]";
+  {
+    this.performTest(() -> {
+      String testInfo = "criteria=[ " + criteria
+          + " ], forceMinimal=[ " + forceMinimal
+          + " ], featureMode=[ " + featureMode
+          + " ], withRelationships=[ " + withRelationships
+          + " ], withRaw=[ " + withRaw + " ]";
 
-    JsonObjectBuilder job = Json.createObjectBuilder();
-    criteria.entrySet().forEach(entry -> {
-      String key = entry.getKey();
-      Set<String> values = entry.getValue();
-      if (values.size() == 1) {
-        job.add(key, values.iterator().next());
-      } else {
-        JsonArrayBuilder jab = Json.createArrayBuilder();
-        for (String value : values) {
-          JsonObjectBuilder job2 = Json.createObjectBuilder();
-          job2.add(key, value);
-          jab.add(job2);
+      JsonObjectBuilder job = Json.createObjectBuilder();
+      criteria.entrySet().forEach(entry -> {
+        String key = entry.getKey();
+        Set<String> values = entry.getValue();
+        if (values.size() == 1) {
+          job.add(key, values.iterator().next());
+        } else {
+          JsonArrayBuilder jab = Json.createArrayBuilder();
+          for (String value : values) {
+            JsonObjectBuilder job2 = Json.createObjectBuilder();
+            job2.add(key, value);
+            jab.add(job2);
+          }
+          job.add(key, jab);
         }
-        job.add(key, jab);
+      });
+      String attrs = JsonUtils.toJsonText(job);
+
+      StringBuilder sb = new StringBuilder();
+      sb.append("entities?attrs=").append(urlEncode(attrs));
+      if (forceMinimal != null) {
+        sb.append("&forceMinimal=").append(forceMinimal);
       }
+      if (featureMode != null) {
+        sb.append("&featureMode=").append(featureMode);
+      }
+      if (withRelationships != null) {
+        sb.append("&withRelationships=").append(withRelationships);
+      }
+      if (withRaw != null) {
+        sb.append("&withRaw=").append(withRaw);
+      }
+      String uriText = this.formatServerUri(sb.toString());
+
+      long before = System.currentTimeMillis();
+      SzAttributeSearchResponse response = this.invokeServerViaHttp(
+          GET, uriText, SzAttributeSearchResponse.class);
+      response.concludeTimers();
+      long after = System.currentTimeMillis();
+
+      this.validateSearchResponse(
+          testInfo,
+          response,
+          uriText,
+          expectedCount,
+          withRelationships,
+          forceMinimal,
+          featureMode,
+          before,
+          after,
+          withRaw);
     });
-    String attrs = JsonUtils.toJsonText(job);
-
-    this.assumeNativeApiAvailable();
-    StringBuilder sb = new StringBuilder();
-    sb.append("entities?attrs=").append(URLEncoder.encode(attrs, "UTF-8"));
-    if (forceMinimal != null) {
-      sb.append("&forceMinimal=").append(forceMinimal);
-    }
-    if (featureMode != null) {
-      sb.append("&featureMode=").append(featureMode);
-    }
-    if (withRelationships != null) {
-      sb.append("&withRelationships=").append(withRelationships);
-    }
-    if (withRaw != null) {
-      sb.append("&withRaw=").append(withRaw);
-    }
-    String uriText = this.formatServerUri(sb.toString());
-
-    long before = System.currentTimeMillis();
-    SzAttributeSearchResponse response = this.invokeServerViaHttp(
-        GET, uriText, SzAttributeSearchResponse.class);
-    response.concludeTimers();
-    long after = System.currentTimeMillis();
-
-    this.validateSearchResponse(
-        testInfo,
-        response,
-        uriText,
-        expectedCount,
-        withRelationships,
-        forceMinimal,
-        featureMode,
-        before,
-        after,
-        withRaw);
   }
 
   @ParameterizedTest
@@ -1629,60 +1647,58 @@ public class EntityDataReadServicesTest extends AbstractServiceTest {
       Boolean forceMinimal,
       SzFeatureInclusion featureMode,
       Boolean withRelationships,
-      Boolean withRaw) {
-    String testInfo = "criteria=[ " + criteria
-        + " ], forceMinimal=[ " + forceMinimal
-        + " ], featureMode=[ " + featureMode
-        + " ], withRelationships=[ " + withRelationships
-        + " ], withRaw=[ " + withRaw + " ]";
+      Boolean withRaw)
+  {
+    this.performTest(() -> {
+      String testInfo = "criteria=[ " + criteria
+          + " ], forceMinimal=[ " + forceMinimal
+          + " ], featureMode=[ " + featureMode
+          + " ], withRelationships=[ " + withRelationships
+          + " ], withRaw=[ " + withRaw + " ]";
 
-    this.assumeNativeApiAvailable();
-    StringBuilder sb = new StringBuilder(criteria.size() * 50);
-    criteria.entrySet().forEach(entry -> {
-      try {
+      StringBuilder sb = new StringBuilder(criteria.size() * 50);
+      criteria.entrySet().forEach(entry -> {
         String key = entry.getKey();
         Set<String> values = entry.getValue();
-        String encodedKey = URLEncoder.encode(key, "UTF-8");
+        String encodedKey = urlEncode(key);
         for (String value : values) {
-          String encodedVal = URLEncoder.encode(value, "UTF-8");
+          String encodedVal = urlEncode(value);
           sb.append("&attr_").append(encodedKey).append("=").append(encodedVal);
         }
-      } catch (UnsupportedEncodingException cannotHappen) {
-        throw new IllegalStateException(cannotHappen);
+      });
+      // replace the "&" with a "?" at the start
+      sb.setCharAt(0, '?');
+      if (forceMinimal != null) {
+        sb.append("&forceMinimal=").append(forceMinimal);
       }
+      if (featureMode != null) {
+        sb.append("&featureMode=").append(featureMode);
+      }
+      if (withRelationships != null) {
+        sb.append("&withRelationships=").append(withRelationships);
+      }
+      if (withRaw != null) {
+        sb.append("&withRaw=").append(withRaw);
+      }
+      String uriText = this.formatServerUri("entities" + sb.toString());
+
+      long before = System.currentTimeMillis();
+      SzAttributeSearchResponse response = this.invokeServerViaHttp(
+          GET, uriText, SzAttributeSearchResponse.class);
+      response.concludeTimers();
+      long after = System.currentTimeMillis();
+
+      this.validateSearchResponse(
+          testInfo,
+          response,
+          uriText,
+          expectedCount,
+          withRelationships,
+          forceMinimal,
+          featureMode,
+          before,
+          after,
+          withRaw);
     });
-    // replace the "&" with a "?" at the start
-    sb.setCharAt(0, '?');
-    if (forceMinimal != null) {
-      sb.append("&forceMinimal=").append(forceMinimal);
-    }
-    if (featureMode != null) {
-      sb.append("&featureMode=").append(featureMode);
-    }
-    if (withRelationships != null) {
-      sb.append("&withRelationships=").append(withRelationships);
-    }
-    if (withRaw != null) {
-      sb.append("&withRaw=").append(withRaw);
-    }
-    String uriText = this.formatServerUri("entities" + sb.toString());
-
-    long before = System.currentTimeMillis();
-    SzAttributeSearchResponse response = this.invokeServerViaHttp(
-        GET, uriText, SzAttributeSearchResponse.class);
-    response.concludeTimers();
-    long after = System.currentTimeMillis();
-
-    this.validateSearchResponse(
-        testInfo,
-        response,
-        uriText,
-        expectedCount,
-        withRelationships,
-        forceMinimal,
-        featureMode,
-        before,
-        after,
-        withRaw);
   }
 }

--- a/src/test/java/com/senzing/api/services/EntityDataWriteServicesTest.java
+++ b/src/test/java/com/senzing/api/services/EntityDataWriteServicesTest.java
@@ -42,102 +42,107 @@ public class EntityDataWriteServicesTest extends AbstractServiceTest {
   }
 
   @AfterAll public void teardownEnvironment() {
-    this.teardownTestEnvironment(true);
+    this.teardownTestEnvironment();
   }
 
   @Test public void postRecordTest() {
-    this.assumeNativeApiAvailable();
-    String  uriText = this.formatServerUri(
-        "data-sources/" + TEST_DATA_SOURCE + "/records");
-    UriInfo uriInfo = this.newProxyUriInfo(uriText);
+    this.performTest(() -> {
+      String  uriText = this.formatServerUri(
+          "data-sources/" + TEST_DATA_SOURCE + "/records");
+      UriInfo uriInfo = this.newProxyUriInfo(uriText);
 
-    JsonObjectBuilder job = Json.createObjectBuilder();
-    job.add("NAME_FIRST", "Joe");
-    job.add("NAME_LAST", "Schmoe");
-    job.add("PHONE_NUMBER", "702-555-1212");
-    job.add("ADDR_FULL", "101 Main Street, Las Vegas, NV 89101");
-    JsonObject  jsonObject  = job.build();
-    String      jsonText    = JsonUtils.toJsonText(jsonObject);
+      JsonObjectBuilder job = Json.createObjectBuilder();
+      job.add("NAME_FIRST", "Joe");
+      job.add("NAME_LAST", "Schmoe");
+      job.add("PHONE_NUMBER", "702-555-1212");
+      job.add("ADDR_FULL", "101 Main Street, Las Vegas, NV 89101");
+      JsonObject  jsonObject  = job.build();
+      String      jsonText    = JsonUtils.toJsonText(jsonObject);
 
-    long before = System.currentTimeMillis();
-    SzLoadRecordResponse response = this.entityDataServices.loadRecord(
-        TEST_DATA_SOURCE, null, uriInfo, jsonText);
-    response.concludeTimers();
-    long after = System.currentTimeMillis();
+      long before = System.currentTimeMillis();
+      SzLoadRecordResponse response = this.entityDataServices.loadRecord(
+          TEST_DATA_SOURCE, null, uriInfo, jsonText);
+      response.concludeTimers();
+      long after = System.currentTimeMillis();
 
-    this.validateLoadRecordResponse(
-        response, POST, TEST_DATA_SOURCE, null, before, after);
+      this.validateLoadRecordResponse(
+          response, POST, TEST_DATA_SOURCE, null, before, after);
+    });
   }
 
   @Test public void postRecordTestViaHttp() {
-    this.assumeNativeApiAvailable();
-    String  uriText = this.formatServerUri(
-        "data-sources/" + TEST_DATA_SOURCE + "/records");
-    UriInfo uriInfo = this.newProxyUriInfo(uriText);
+    this.performTest(() -> {
+      String  uriText = this.formatServerUri(
+          "data-sources/" + TEST_DATA_SOURCE + "/records");
+      UriInfo uriInfo = this.newProxyUriInfo(uriText);
 
-    Map recordBody = new HashMap();
-    recordBody.put("NAME_FIRST", "Joanne");
-    recordBody.put("NAME_LAST", "Smith");
-    recordBody.put("PHONE_NUMBER", "212-555-1212");
-    recordBody.put("ADDR_FULL", "101 Fifth Ave, Las Vegas, NV 10018");
+      Map recordBody = new HashMap();
+      recordBody.put("NAME_FIRST", "Joanne");
+      recordBody.put("NAME_LAST", "Smith");
+      recordBody.put("PHONE_NUMBER", "212-555-1212");
+      recordBody.put("ADDR_FULL", "101 Fifth Ave, Las Vegas, NV 10018");
 
-    long before = System.currentTimeMillis();
-    SzLoadRecordResponse response = this.invokeServerViaHttp(
-        POST, uriText, null, recordBody, SzLoadRecordResponse.class);
-    response.concludeTimers();
-    long after = System.currentTimeMillis();
+      long before = System.currentTimeMillis();
+      SzLoadRecordResponse response = this.invokeServerViaHttp(
+          POST, uriText, null, recordBody, SzLoadRecordResponse.class);
+      response.concludeTimers();
+      long after = System.currentTimeMillis();
 
-    this.validateLoadRecordResponse(
-        response, POST, TEST_DATA_SOURCE, null, before, after);
+      this.validateLoadRecordResponse(
+          response, POST, TEST_DATA_SOURCE, null, before, after);
+    });
   }
 
   @Test public void putRecordTest() {
-    final String recordId = "ABC123";
+    this.performTest(() -> {
+      final String recordId = "ABC123";
 
-    this.assumeNativeApiAvailable();
-    String  uriText = this.formatServerUri(
-        "data-sources/" + TEST_DATA_SOURCE + "/records/" + recordId);
-    UriInfo uriInfo = this.newProxyUriInfo(uriText);
+      String  uriText = this.formatServerUri(
+          "data-sources/" + TEST_DATA_SOURCE + "/records/" + recordId);
+      UriInfo uriInfo = this.newProxyUriInfo(uriText);
 
-    JsonObjectBuilder job = Json.createObjectBuilder();
-    job.add("NAME_FIRST", "John");
-    job.add("NAME_LAST", "Doe");
-    job.add("PHONE_NUMBER", "818-555-1313");
-    job.add("ADDR_FULL", "100 Main Street, Los Angeles, CA 90012");
-    JsonObject  jsonObject  = job.build();
-    String      jsonText    = JsonUtils.toJsonText(jsonObject);
+      JsonObjectBuilder job = Json.createObjectBuilder();
+      job.add("NAME_FIRST", "John");
+      job.add("NAME_LAST", "Doe");
+      job.add("PHONE_NUMBER", "818-555-1313");
+      job.add("ADDR_FULL", "100 Main Street, Los Angeles, CA 90012");
+      JsonObject  jsonObject  = job.build();
+      String      jsonText    = JsonUtils.toJsonText(jsonObject);
 
-    long before = System.currentTimeMillis();
-    SzLoadRecordResponse response = this.entityDataServices.loadRecord(
-        TEST_DATA_SOURCE, recordId, null, uriInfo, jsonText);
-    response.concludeTimers();
-    long after = System.currentTimeMillis();
+      long before = System.currentTimeMillis();
+      SzLoadRecordResponse response = this.entityDataServices.loadRecord(
+          TEST_DATA_SOURCE, recordId, null, uriInfo, jsonText);
+      response.concludeTimers();
+      long after = System.currentTimeMillis();
 
-    this.validateLoadRecordResponse(
-        response, PUT, TEST_DATA_SOURCE, recordId, before, after);
+      this.validateLoadRecordResponse(
+          response, PUT, TEST_DATA_SOURCE, recordId, before, after);
+    });
   }
 
   @Test public void putRecordTestViaHttp() {
-    final String recordId = "XYZ456";
+    this.performTest(() -> {
+      final String recordId = "XYZ456";
 
-    this.assumeNativeApiAvailable();
-    String  uriText = this.formatServerUri(
-        "data-sources/" + TEST_DATA_SOURCE + "/records/" + recordId);
-    UriInfo uriInfo = this.newProxyUriInfo(uriText);
+      String  uriText = this.formatServerUri(
+          "data-sources/" + TEST_DATA_SOURCE + "/records/" + recordId);
+      UriInfo uriInfo = this.newProxyUriInfo(uriText);
 
-    Map recordBody = new HashMap();
-    recordBody.put("NAME_FIRST", "Jane");
-    recordBody.put("NAME_LAST", "Doe");
-    recordBody.put("PHONE_NUMBER", "818-555-1212");
-    recordBody.put("ADDR_FULL", "500 First Street, Los Angeles, CA 90033");
+      Map recordBody = new HashMap();
+      recordBody.put("NAME_FIRST", "Jane");
+      recordBody.put("NAME_LAST", "Doe");
+      recordBody.put("PHONE_NUMBER", "818-555-1212");
+      recordBody.put("ADDR_FULL", "500 First Street, Los Angeles, CA 90033");
 
-    long before = System.currentTimeMillis();
-    SzLoadRecordResponse response = this.invokeServerViaHttp(
-        PUT, uriText, null, recordBody, SzLoadRecordResponse.class);
-    response.concludeTimers();
-    long after = System.currentTimeMillis();
+      long before = System.currentTimeMillis();
+      SzLoadRecordResponse response = this.invokeServerViaHttp(
+          PUT, uriText, null, recordBody, SzLoadRecordResponse.class);
+      response.concludeTimers();
+      long after = System.currentTimeMillis();
 
-    this.validateLoadRecordResponse(
-        response, PUT, TEST_DATA_SOURCE, recordId, before, after);
+      this.validateLoadRecordResponse(
+          response, PUT, TEST_DATA_SOURCE, recordId, before, after);
+
+    });
   }
 }

--- a/src/test/java/com/senzing/api/services/EntityGraphServicesTest.java
+++ b/src/test/java/com/senzing/api/services/EntityGraphServicesTest.java
@@ -169,7 +169,7 @@ public class EntityGraphServicesTest extends AbstractServiceTest {
 
   @AfterAll
   public void teardownEnvironment() {
-    this.teardownTestEnvironment(true);
+    this.teardownTestEnvironment();
   }
 
   private Long getEntityIdForRecordId(SzRecordId recordId) {
@@ -485,85 +485,85 @@ public class EntityGraphServicesTest extends AbstractServiceTest {
                                     Integer                 expectedPathLength,
                                     List<SzRecordId>        expectedPath)
   {
-    String testInfo = "fromRecord=[ " + fromRecordId
-        + " ], toRecord=[ " + toRecordId
-        + " ], maxDegrees=[ " + maxDegrees
-        + " ], avoidParam=[ " + avoidParam
-        + " ], avoidList=[ " + avoidList
-        + " ], forbidAvoided=[ " + forbidAvoided
-        + " ], sources=[ " + sourcesParam
-        + " ], forceMinimal=[ " + forceMinimal
-        + " ], featureMode=[ " + featureMode
-        + " ], withRaw=[ " + withRaw + " ]";
+    this.performTest(() -> {
+      String testInfo = "fromRecord=[ " + fromRecordId
+          + " ], toRecord=[ " + toRecordId
+          + " ], maxDegrees=[ " + maxDegrees
+          + " ], avoidParam=[ " + avoidParam
+          + " ], avoidList=[ " + avoidList
+          + " ], forbidAvoided=[ " + forbidAvoided
+          + " ], sources=[ " + sourcesParam
+          + " ], forceMinimal=[ " + forceMinimal
+          + " ], featureMode=[ " + featureMode
+          + " ], withRaw=[ " + withRaw + " ]";
 
-    this.assumeNativeApiAvailable();
+      SzEntityIdentifier fromIdentifer
+          = this.normalizeIdentifier(fromRecordId,false);
 
-    SzEntityIdentifier fromIdentifer
-        = this.normalizeIdentifier(fromRecordId,false);
+      SzEntityIdentifier toIdentifier
+          = this.normalizeIdentifier(toRecordId,false);
 
-    SzEntityIdentifier toIdentifier
-        = this.normalizeIdentifier(toRecordId,false);
+      SzEntityIdentifiers avoidParamIds
+          = this.normalizeIdentifiers(avoidParam,false);
 
-    SzEntityIdentifiers avoidParamIds
-        = this.normalizeIdentifiers(avoidParam,false);
+      SzEntityIdentifiers avoidListIds
+          = this.normalizeIdentifiers(avoidList,false);
 
-    SzEntityIdentifiers avoidListIds
-        = this.normalizeIdentifiers(avoidList,false);
+      StringBuilder sb = new StringBuilder();
+      sb.append("entity-paths");
 
-    StringBuilder sb = new StringBuilder();
-    sb.append("entity-paths");
+      buildPathQueryString(sb,
+                           fromIdentifer,
+                           toIdentifier,
+                           maxDegrees,
+                           avoidParamIds,
+                           avoidListIds,
+                           forbidAvoided,
+                           sourcesParam,
+                           forceMinimal,
+                           featureMode,
+                           withRaw);
 
-    buildPathQueryString(sb,
-                         fromIdentifer,
-                         toIdentifier,
-                         maxDegrees,
-                         avoidParamIds,
-                         avoidListIds,
-                         forbidAvoided,
-                         sourcesParam,
-                         forceMinimal,
-                         featureMode,
-                         withRaw);
+      String uriText = this.formatServerUri(sb.toString());
+      UriInfo uriInfo = this.newProxyUriInfo(uriText);
 
-    String uriText = this.formatServerUri(sb.toString());
-    UriInfo uriInfo = this.newProxyUriInfo(uriText);
+      long before = System.currentTimeMillis();
 
-    long before = System.currentTimeMillis();
+      SzEntityPathResponse response = this.entityGraphServices.getEntityPath(
+          fromIdentifer.toString(),
+          toIdentifier.toString(),
+          (maxDegrees == null ? DEFAULT_PATH_DEGREES : maxDegrees),
+          formatIdentifierParam(avoidParamIds),
+          formatIdentifierList(avoidListIds),
+          (forbidAvoided == null ? false : forbidAvoided),
+          sourcesParam,
+          (forceMinimal == null ? false : forceMinimal),
+          (featureMode == null ? WITH_DUPLICATES : featureMode),
+          (withRaw == null ? false : withRaw),
+          uriInfo);
 
-    SzEntityPathResponse response = this.entityGraphServices.getEntityPath(
-        fromIdentifer.toString(),
-        toIdentifier.toString(),
-        (maxDegrees == null ? DEFAULT_PATH_DEGREES : maxDegrees),
-        formatIdentifierParam(avoidParamIds),
-        formatIdentifierList(avoidListIds),
-        (forbidAvoided == null ? false : forbidAvoided),
-        sourcesParam,
-        (forceMinimal == null ? false : forceMinimal),
-        (featureMode == null ? WITH_DUPLICATES : featureMode),
-        (withRaw == null ? false : withRaw),
-        uriInfo);
+      response.concludeTimers();
+      long after = System.currentTimeMillis();
 
-    response.concludeTimers();
-    long after = System.currentTimeMillis();
-
-    this.validateEntityPathResponse(
-        testInfo,
-        response,
-        uriText,
-        fromIdentifer,
-        toIdentifier,
-        (maxDegrees != null ? maxDegrees : DEFAULT_PATH_DEGREES),
-        avoidParamIds,
-        avoidListIds,
-        forbidAvoided,
-        sourcesParam,
-        forceMinimal,
-        featureMode,
-        withRaw,
-        expectedPathLength,
-        expectedPath,
-        before,
-        after);
+      this.validateEntityPathResponse(
+          testInfo,
+          response,
+          uriText,
+          fromIdentifer,
+          toIdentifier,
+          (maxDegrees != null ? maxDegrees : DEFAULT_PATH_DEGREES),
+          avoidParamIds,
+          avoidListIds,
+          forbidAvoided,
+          sourcesParam,
+          forceMinimal,
+          featureMode,
+          withRaw,
+          expectedPathLength,
+          expectedPath,
+          before,
+          after);
+    });
   }
 
   @ParameterizedTest
@@ -582,73 +582,73 @@ public class EntityGraphServicesTest extends AbstractServiceTest {
       Integer                 expectedPathLength,
       List<SzRecordId>        expectedPath)
   {
-    String testInfo = "fromRecord=[ " + fromRecordId
-        + " ], toRecord=[ " + toRecordId
-        + " ], maxDegrees=[ " + maxDegrees
-        + " ], avoidParam=[ " + avoidParam
-        + " ], avoidList=[ " + avoidList
-        + " ], forbidAvoided=[ " + forbidAvoided
-        + " ], sources=[ " + sourcesParam
-        + " ], forceMinimal=[ " + forceMinimal
-        + " ], featureMode=[ " + featureMode
-        + " ], withRaw=[ " + withRaw + " ]";
+    this.performTest(() -> {
+      String testInfo = "fromRecord=[ " + fromRecordId
+          + " ], toRecord=[ " + toRecordId
+          + " ], maxDegrees=[ " + maxDegrees
+          + " ], avoidParam=[ " + avoidParam
+          + " ], avoidList=[ " + avoidList
+          + " ], forbidAvoided=[ " + forbidAvoided
+          + " ], sources=[ " + sourcesParam
+          + " ], forceMinimal=[ " + forceMinimal
+          + " ], featureMode=[ " + featureMode
+          + " ], withRaw=[ " + withRaw + " ]";
 
-    this.assumeNativeApiAvailable();
+      SzEntityIdentifier fromIdentifer
+          = this.normalizeIdentifier(fromRecordId,false);
 
-    SzEntityIdentifier fromIdentifer
-        = this.normalizeIdentifier(fromRecordId,false);
+      SzEntityIdentifier toIdentifier
+          = this.normalizeIdentifier(toRecordId,false);
 
-    SzEntityIdentifier toIdentifier
-        = this.normalizeIdentifier(toRecordId,false);
+      SzEntityIdentifiers avoidParamIds
+          = this.normalizeIdentifiers(avoidParam,false);
 
-    SzEntityIdentifiers avoidParamIds
-        = this.normalizeIdentifiers(avoidParam,false);
+      SzEntityIdentifiers avoidListIds
+          = this.normalizeIdentifiers(avoidList,false);
 
-    SzEntityIdentifiers avoidListIds
-        = this.normalizeIdentifiers(avoidList,false);
+      StringBuilder sb = new StringBuilder();
+      sb.append("entity-paths");
 
-    StringBuilder sb = new StringBuilder();
-    sb.append("entity-paths");
+      buildPathQueryString(sb,
+                           fromIdentifer,
+                           toIdentifier,
+                           maxDegrees,
+                           avoidParamIds,
+                           avoidListIds,
+                           forbidAvoided,
+                           sourcesParam,
+                           forceMinimal,
+                           featureMode,
+                           withRaw);
 
-    buildPathQueryString(sb,
-                         fromIdentifer,
-                         toIdentifier,
-                         maxDegrees,
-                         avoidParamIds,
-                         avoidListIds,
-                         forbidAvoided,
-                         sourcesParam,
-                         forceMinimal,
-                         featureMode,
-                         withRaw);
+      String uriText = this.formatServerUri(sb.toString());
+      UriInfo uriInfo = this.newProxyUriInfo(uriText);
 
-    String uriText = this.formatServerUri(sb.toString());
-    UriInfo uriInfo = this.newProxyUriInfo(uriText);
+      long before = System.currentTimeMillis();
+      SzEntityPathResponse response = this.invokeServerViaHttp(
+          GET, uriText, SzEntityPathResponse.class);
+      response.concludeTimers();
+      long after = System.currentTimeMillis();
 
-    long before = System.currentTimeMillis();
-    SzEntityPathResponse response = this.invokeServerViaHttp(
-        GET, uriText, SzEntityPathResponse.class);
-    response.concludeTimers();
-    long after = System.currentTimeMillis();
-
-    this.validateEntityPathResponse(
-        testInfo,
-        response,
-        uriText,
-        fromIdentifer,
-        toIdentifier,
-        (maxDegrees != null ? maxDegrees : DEFAULT_PATH_DEGREES),
-        avoidParamIds,
-        avoidListIds,
-        forbidAvoided,
-        sourcesParam,
-        forceMinimal,
-        featureMode,
-        withRaw,
-        expectedPathLength,
-        expectedPath,
-        before,
-        after);
+      this.validateEntityPathResponse(
+          testInfo,
+          response,
+          uriText,
+          fromIdentifer,
+          toIdentifier,
+          (maxDegrees != null ? maxDegrees : DEFAULT_PATH_DEGREES),
+          avoidParamIds,
+          avoidListIds,
+          forbidAvoided,
+          sourcesParam,
+          forceMinimal,
+          featureMode,
+          withRaw,
+          expectedPathLength,
+          expectedPath,
+          before,
+          after);
+    });
   }
 
   @ParameterizedTest
@@ -666,85 +666,85 @@ public class EntityGraphServicesTest extends AbstractServiceTest {
                                     Integer                 expectedPathLength,
                                     List<SzRecordId>        expectedPath)
   {
-    String testInfo = "fromRecord=[ " + fromRecordId
-        + " ], toRecord=[ " + toRecordId
-        + " ], maxDegrees=[ " + maxDegrees
-        + " ], avoidParam=[ " + avoidParam
-        + " ], avoidList=[ " + avoidList
-        + " ], forbidAvoided=[ " + forbidAvoided
-        + " ], sources=[ " + sourcesParam
-        + " ], forceMinimal=[ " + forceMinimal
-        + " ], featureMode=[ " + featureMode
-        + " ], withRaw=[ " + withRaw + " ]";
+    this.performTest(() -> {
+      String testInfo = "fromRecord=[ " + fromRecordId
+          + " ], toRecord=[ " + toRecordId
+          + " ], maxDegrees=[ " + maxDegrees
+          + " ], avoidParam=[ " + avoidParam
+          + " ], avoidList=[ " + avoidList
+          + " ], forbidAvoided=[ " + forbidAvoided
+          + " ], sources=[ " + sourcesParam
+          + " ], forceMinimal=[ " + forceMinimal
+          + " ], featureMode=[ " + featureMode
+          + " ], withRaw=[ " + withRaw + " ]";
 
-    this.assumeNativeApiAvailable();
+      SzEntityIdentifier fromIdentifer
+          = this.normalizeIdentifier(fromRecordId,true);
 
-    SzEntityIdentifier fromIdentifer
-        = this.normalizeIdentifier(fromRecordId,true);
+      SzEntityIdentifier toIdentifier
+          = this.normalizeIdentifier(toRecordId,true);
 
-    SzEntityIdentifier toIdentifier
-        = this.normalizeIdentifier(toRecordId,true);
+      SzEntityIdentifiers avoidParamIds
+          = this.normalizeIdentifiers(avoidParam,true);
 
-    SzEntityIdentifiers avoidParamIds
-        = this.normalizeIdentifiers(avoidParam,true);
+      SzEntityIdentifiers avoidListIds
+          = this.normalizeIdentifiers(avoidList,true);
 
-    SzEntityIdentifiers avoidListIds
-        = this.normalizeIdentifiers(avoidList,true);
+      StringBuilder sb = new StringBuilder();
+      sb.append("entity-paths");
 
-    StringBuilder sb = new StringBuilder();
-    sb.append("entity-paths");
+      buildPathQueryString(sb,
+                           fromIdentifer,
+                           toIdentifier,
+                           maxDegrees,
+                           avoidParamIds,
+                           avoidListIds,
+                           forbidAvoided,
+                           sourcesParam,
+                           forceMinimal,
+                           featureMode,
+                           withRaw);
 
-    buildPathQueryString(sb,
-                         fromIdentifer,
-                         toIdentifier,
-                         maxDegrees,
-                         avoidParamIds,
-                         avoidListIds,
-                         forbidAvoided,
-                         sourcesParam,
-                         forceMinimal,
-                         featureMode,
-                         withRaw);
+      String uriText = this.formatServerUri(sb.toString());
+      UriInfo uriInfo = this.newProxyUriInfo(uriText);
 
-    String uriText = this.formatServerUri(sb.toString());
-    UriInfo uriInfo = this.newProxyUriInfo(uriText);
+      long before = System.currentTimeMillis();
 
-    long before = System.currentTimeMillis();
+      SzEntityPathResponse response = this.entityGraphServices.getEntityPath(
+          fromIdentifer.toString(),
+          toIdentifier.toString(),
+          (maxDegrees == null ? DEFAULT_PATH_DEGREES : maxDegrees),
+          formatIdentifierParam(avoidParamIds),
+          formatIdentifierList(avoidListIds),
+          (forbidAvoided == null ? false : forbidAvoided),
+          sourcesParam,
+          (forceMinimal == null ? false : forceMinimal),
+          (featureMode == null ? WITH_DUPLICATES : featureMode),
+          (withRaw == null ? false : withRaw),
+          uriInfo);
 
-    SzEntityPathResponse response = this.entityGraphServices.getEntityPath(
-        fromIdentifer.toString(),
-        toIdentifier.toString(),
-        (maxDegrees == null ? DEFAULT_PATH_DEGREES : maxDegrees),
-        formatIdentifierParam(avoidParamIds),
-        formatIdentifierList(avoidListIds),
-        (forbidAvoided == null ? false : forbidAvoided),
-        sourcesParam,
-        (forceMinimal == null ? false : forceMinimal),
-        (featureMode == null ? WITH_DUPLICATES : featureMode),
-        (withRaw == null ? false : withRaw),
-        uriInfo);
+      response.concludeTimers();
+      long after = System.currentTimeMillis();
 
-    response.concludeTimers();
-    long after = System.currentTimeMillis();
-
-    this.validateEntityPathResponse(
-        testInfo,
-        response,
-        uriText,
-        fromIdentifer,
-        toIdentifier,
-        (maxDegrees != null ? maxDegrees : DEFAULT_PATH_DEGREES),
-        avoidParamIds,
-        avoidListIds,
-        forbidAvoided,
-        sourcesParam,
-        forceMinimal,
-        featureMode,
-        withRaw,
-        expectedPathLength,
-        expectedPath,
-        before,
-        after);
+      this.validateEntityPathResponse(
+          testInfo,
+          response,
+          uriText,
+          fromIdentifer,
+          toIdentifier,
+          (maxDegrees != null ? maxDegrees : DEFAULT_PATH_DEGREES),
+          avoidParamIds,
+          avoidListIds,
+          forbidAvoided,
+          sourcesParam,
+          forceMinimal,
+          featureMode,
+          withRaw,
+          expectedPathLength,
+          expectedPath,
+          before,
+          after);
+    });
   }
 
   @ParameterizedTest
@@ -763,73 +763,73 @@ public class EntityGraphServicesTest extends AbstractServiceTest {
       Integer                 expectedPathLength,
       List<SzRecordId>        expectedPath)
   {
-    String testInfo = "fromRecord=[ " + fromRecordId
-        + " ], toRecord=[ " + toRecordId
-        + " ], maxDegrees=[ " + maxDegrees
-        + " ], avoidParam=[ " + avoidParam
-        + " ], avoidList=[ " + avoidList
-        + " ], forbidAvoided=[ " + forbidAvoided
-        + " ], sources=[ " + sourcesParam
-        + " ], forceMinimal=[ " + forceMinimal
-        + " ], featureMode=[ " + featureMode
-        + " ], withRaw=[ " + withRaw + " ]";
+    this.performTest(() -> {
+      String testInfo = "fromRecord=[ " + fromRecordId
+          + " ], toRecord=[ " + toRecordId
+          + " ], maxDegrees=[ " + maxDegrees
+          + " ], avoidParam=[ " + avoidParam
+          + " ], avoidList=[ " + avoidList
+          + " ], forbidAvoided=[ " + forbidAvoided
+          + " ], sources=[ " + sourcesParam
+          + " ], forceMinimal=[ " + forceMinimal
+          + " ], featureMode=[ " + featureMode
+          + " ], withRaw=[ " + withRaw + " ]";
 
-    this.assumeNativeApiAvailable();
+      SzEntityIdentifier fromIdentifer
+          = this.normalizeIdentifier(fromRecordId,true);
 
-    SzEntityIdentifier fromIdentifer
-        = this.normalizeIdentifier(fromRecordId,true);
+      SzEntityIdentifier toIdentifier
+          = this.normalizeIdentifier(toRecordId,true);
 
-    SzEntityIdentifier toIdentifier
-        = this.normalizeIdentifier(toRecordId,true);
+      SzEntityIdentifiers avoidParamIds
+          = this.normalizeIdentifiers(avoidParam,true);
 
-    SzEntityIdentifiers avoidParamIds
-        = this.normalizeIdentifiers(avoidParam,true);
+      SzEntityIdentifiers avoidListIds
+          = this.normalizeIdentifiers(avoidList,true);
 
-    SzEntityIdentifiers avoidListIds
-        = this.normalizeIdentifiers(avoidList,true);
+      StringBuilder sb = new StringBuilder();
+      sb.append("entity-paths");
 
-    StringBuilder sb = new StringBuilder();
-    sb.append("entity-paths");
+      buildPathQueryString(sb,
+                           fromIdentifer,
+                           toIdentifier,
+                           maxDegrees,
+                           avoidParamIds,
+                           avoidListIds,
+                           forbidAvoided,
+                           sourcesParam,
+                           forceMinimal,
+                           featureMode,
+                           withRaw);
 
-    buildPathQueryString(sb,
-                         fromIdentifer,
-                         toIdentifier,
-                         maxDegrees,
-                         avoidParamIds,
-                         avoidListIds,
-                         forbidAvoided,
-                         sourcesParam,
-                         forceMinimal,
-                         featureMode,
-                         withRaw);
+      String uriText = this.formatServerUri(sb.toString());
+      UriInfo uriInfo = this.newProxyUriInfo(uriText);
 
-    String uriText = this.formatServerUri(sb.toString());
-    UriInfo uriInfo = this.newProxyUriInfo(uriText);
+      long before = System.currentTimeMillis();
+      SzEntityPathResponse response = this.invokeServerViaHttp(
+          GET, uriText, SzEntityPathResponse.class);
+      response.concludeTimers();
+      long after = System.currentTimeMillis();
 
-    long before = System.currentTimeMillis();
-    SzEntityPathResponse response = this.invokeServerViaHttp(
-        GET, uriText, SzEntityPathResponse.class);
-    response.concludeTimers();
-    long after = System.currentTimeMillis();
-
-    this.validateEntityPathResponse(
-        testInfo,
-        response,
-        uriText,
-        fromIdentifer,
-        toIdentifier,
-        (maxDegrees != null ? maxDegrees : DEFAULT_PATH_DEGREES),
-        avoidParamIds,
-        avoidListIds,
-        forbidAvoided,
-        sourcesParam,
-        forceMinimal,
-        featureMode,
-        withRaw,
-        expectedPathLength,
-        expectedPath,
-        before,
-        after);
+      this.validateEntityPathResponse(
+          testInfo,
+          response,
+          uriText,
+          fromIdentifer,
+          toIdentifier,
+          (maxDegrees != null ? maxDegrees : DEFAULT_PATH_DEGREES),
+          avoidParamIds,
+          avoidListIds,
+          forbidAvoided,
+          sourcesParam,
+          forceMinimal,
+          featureMode,
+          withRaw,
+          expectedPathLength,
+          expectedPath,
+          before,
+          after);
+    });
   }
 
   private void validateEntityPathResponse(
@@ -1270,7 +1270,8 @@ public class EntityGraphServicesTest extends AbstractServiceTest {
       List<List<SzRecordId>>   expectedPaths,
       Set<SzRecordId>          expectedEntities)
   {
-    String testInfo = "entityParam=[ " + entityParam
+    this.performTest(() -> {
+      String testInfo = "entityParam=[ " + entityParam
         + " ], entityList=[ " + entityList
         + " ], maxDegrees=[ " + maxDegrees
         + " ], buildOut=[ " + buildOut
@@ -1279,64 +1280,63 @@ public class EntityGraphServicesTest extends AbstractServiceTest {
         + " ], featureMode=[ " + featureMode
         + " ], withRaw=[ " + withRaw + " ]";
 
-    this.assumeNativeApiAvailable();
+      SzEntityIdentifiers entityParamIds
+          = this.normalizeIdentifiers(entityParam,false);
 
-    SzEntityIdentifiers entityParamIds
-        = this.normalizeIdentifiers(entityParam,false);
+      SzEntityIdentifiers entityListIds
+          = this.normalizeIdentifiers(entityList,false);
 
-    SzEntityIdentifiers entityListIds
-        = this.normalizeIdentifiers(entityList,false);
+      StringBuilder sb = new StringBuilder();
+      sb.append("entity-networks");
 
-    StringBuilder sb = new StringBuilder();
-    sb.append("entity-networks");
+      buildNetworkQueryString(sb,
+                              entityParamIds,
+                              entityListIds,
+                              maxDegrees,
+                              buildOut,
+                              maxEntities,
+                              forceMinimal,
+                              featureMode,
+                              withRaw);
 
-    buildNetworkQueryString(sb,
-                            entityParamIds,
-                            entityListIds,
-                            maxDegrees,
-                            buildOut,
-                            maxEntities,
-                            forceMinimal,
-                            featureMode,
-                            withRaw);
+      String uriText = this.formatServerUri(sb.toString());
+      UriInfo uriInfo = this.newProxyUriInfo(uriText);
 
-    String uriText = this.formatServerUri(sb.toString());
-    UriInfo uriInfo = this.newProxyUriInfo(uriText);
+      long before = System.currentTimeMillis();
 
-    long before = System.currentTimeMillis();
+      SzEntityNetworkResponse response
+          = this.entityGraphServices.getEntityNetwork(
+          formatIdentifierParam(entityParamIds),
+          formatIdentifierList(entityListIds),
+          (maxDegrees == null   ? DEFAULT_NETWORK_DEGREES : maxDegrees),
+          (buildOut == null     ? DEFAULT_BUILD_OUT : buildOut),
+          (maxEntities == null  ? DEFAULT_MAX_ENTITIES : maxEntities),
+          (forceMinimal == null ? false : forceMinimal),
+          (featureMode == null  ? WITH_DUPLICATES : featureMode),
+          (withRaw == null      ? false : withRaw),
+          uriInfo);
 
-    SzEntityNetworkResponse response
-        = this.entityGraphServices.getEntityNetwork(
-            formatIdentifierParam(entityParamIds),
-            formatIdentifierList(entityListIds),
-            (maxDegrees == null   ? DEFAULT_NETWORK_DEGREES : maxDegrees),
-            (buildOut == null     ? DEFAULT_BUILD_OUT : buildOut),
-            (maxEntities == null  ? DEFAULT_MAX_ENTITIES : maxEntities),
-            (forceMinimal == null ? false : forceMinimal),
-            (featureMode == null  ? WITH_DUPLICATES : featureMode),
-            (withRaw == null      ? false : withRaw),
-            uriInfo);
+      response.concludeTimers();
+      long after = System.currentTimeMillis();
 
-    response.concludeTimers();
-    long after = System.currentTimeMillis();
-
-    this.validateEntityNetworkResponse(
-        testInfo,
-        response,
-        uriText,
-        entityParamIds,
-        entityListIds,
-        (maxDegrees != null) ? maxDegrees : DEFAULT_NETWORK_DEGREES,
-        (buildOut != null) ? buildOut : DEFAULT_BUILD_OUT,
-        (maxEntities != null) ? maxEntities : DEFAULT_MAX_ENTITIES,
-        forceMinimal,
-        featureMode,
-        withRaw,
-        expectedPathCount,
-        expectedPaths,
-        expectedEntities,
-        before,
-        after);
+      this.validateEntityNetworkResponse(
+          testInfo,
+          response,
+          uriText,
+          entityParamIds,
+          entityListIds,
+          (maxDegrees != null) ? maxDegrees : DEFAULT_NETWORK_DEGREES,
+          (buildOut != null) ? buildOut : DEFAULT_BUILD_OUT,
+          (maxEntities != null) ? maxEntities : DEFAULT_MAX_ENTITIES,
+          forceMinimal,
+          featureMode,
+          withRaw,
+          expectedPathCount,
+          expectedPaths,
+          expectedEntities,
+          before,
+          after);
+    });
   }
 
   @ParameterizedTest
@@ -1354,62 +1354,62 @@ public class EntityGraphServicesTest extends AbstractServiceTest {
       List<List<SzRecordId>>   expectedPaths,
       Set<SzRecordId>          expectedEntities)
   {
-    String testInfo = "entityParam=[ " + entityParam
-        + " ], entityList=[ " + entityList
-        + " ], maxDegrees=[ " + maxDegrees
-        + " ], buildOut=[ " + buildOut
-        + " ], maxEntities=[ " + maxEntities
-        + " ], forceMinimal=[ " + forceMinimal
-        + " ], featureMode=[ " + featureMode
-        + " ], withRaw=[ " + withRaw + " ]";
+    this.performTest(() -> {
+      String testInfo = "entityParam=[ " + entityParam
+          + " ], entityList=[ " + entityList
+          + " ], maxDegrees=[ " + maxDegrees
+          + " ], buildOut=[ " + buildOut
+          + " ], maxEntities=[ " + maxEntities
+          + " ], forceMinimal=[ " + forceMinimal
+          + " ], featureMode=[ " + featureMode
+          + " ], withRaw=[ " + withRaw + " ]";
 
-    this.assumeNativeApiAvailable();
+      SzEntityIdentifiers entityParamIds
+          = this.normalizeIdentifiers(entityParam,false);
 
-    SzEntityIdentifiers entityParamIds
-        = this.normalizeIdentifiers(entityParam,false);
+      SzEntityIdentifiers entityListIds
+          = this.normalizeIdentifiers(entityList,false);
 
-    SzEntityIdentifiers entityListIds
-        = this.normalizeIdentifiers(entityList,false);
+      StringBuilder sb = new StringBuilder();
+      sb.append("entity-networks");
 
-    StringBuilder sb = new StringBuilder();
-    sb.append("entity-networks");
+      buildNetworkQueryString(sb,
+                              entityParamIds,
+                              entityListIds,
+                              maxDegrees,
+                              buildOut,
+                              maxEntities,
+                              forceMinimal,
+                              featureMode,
+                              withRaw);
 
-    buildNetworkQueryString(sb,
-                            entityParamIds,
-                            entityListIds,
-                            maxDegrees,
-                            buildOut,
-                            maxEntities,
-                            forceMinimal,
-                            featureMode,
-                            withRaw);
+      String uriText = this.formatServerUri(sb.toString());
 
-    String uriText = this.formatServerUri(sb.toString());
+      long before = System.currentTimeMillis();
 
-    long before = System.currentTimeMillis();
+      SzEntityNetworkResponse response = this.invokeServerViaHttp(
+          GET, uriText, SzEntityNetworkResponse.class);
+      response.concludeTimers();
+      long after = System.currentTimeMillis();
 
-    SzEntityNetworkResponse response = this.invokeServerViaHttp(
-        GET, uriText, SzEntityNetworkResponse.class);
-    response.concludeTimers();
-    long after = System.currentTimeMillis();
-
-    this.validateEntityNetworkResponse(
-        testInfo,
-        response,
-        uriText,
-        entityParamIds,
-        entityListIds,
-        (maxDegrees != null) ? maxDegrees : DEFAULT_NETWORK_DEGREES,
-        (buildOut != null) ? buildOut : DEFAULT_BUILD_OUT,
-        (maxEntities != null) ? maxEntities : DEFAULT_MAX_ENTITIES,
-        forceMinimal,
-        featureMode,
-        withRaw,
-        expectedPathCount,
-        expectedPaths,
-        expectedEntities,
-        before,
-        after);
+      this.validateEntityNetworkResponse(
+          testInfo,
+          response,
+          uriText,
+          entityParamIds,
+          entityListIds,
+          (maxDegrees != null) ? maxDegrees : DEFAULT_NETWORK_DEGREES,
+          (buildOut != null) ? buildOut : DEFAULT_BUILD_OUT,
+          (maxEntities != null) ? maxEntities : DEFAULT_MAX_ENTITIES,
+          forceMinimal,
+          featureMode,
+          withRaw,
+          expectedPathCount,
+          expectedPaths,
+          expectedEntities,
+          before,
+          after);
+    });
   }
 
   @ParameterizedTest
@@ -1427,73 +1427,73 @@ public class EntityGraphServicesTest extends AbstractServiceTest {
       List<List<SzRecordId>>   expectedPaths,
       Set<SzRecordId>          expectedEntities)
   {
-    String testInfo = "entityParam=[ " + entityParam
-        + " ], entityList=[ " + entityList
-        + " ], maxDegrees=[ " + maxDegrees
-        + " ], buildOut=[ " + buildOut
-        + " ], maxEntities=[ " + maxEntities
-        + " ], forceMinimal=[ " + forceMinimal
-        + " ], featureMode=[ " + featureMode
-        + " ], withRaw=[ " + withRaw + " ]";
+    this.performTest(() -> {
+      String testInfo = "entityParam=[ " + entityParam
+          + " ], entityList=[ " + entityList
+          + " ], maxDegrees=[ " + maxDegrees
+          + " ], buildOut=[ " + buildOut
+          + " ], maxEntities=[ " + maxEntities
+          + " ], forceMinimal=[ " + forceMinimal
+          + " ], featureMode=[ " + featureMode
+          + " ], withRaw=[ " + withRaw + " ]";
 
-    this.assumeNativeApiAvailable();
+      SzEntityIdentifiers entityParamIds
+          = this.normalizeIdentifiers(entityParam,true);
 
-    SzEntityIdentifiers entityParamIds
-        = this.normalizeIdentifiers(entityParam,true);
+      SzEntityIdentifiers entityListIds
+          = this.normalizeIdentifiers(entityList,true);
 
-    SzEntityIdentifiers entityListIds
-        = this.normalizeIdentifiers(entityList,true);
+      StringBuilder sb = new StringBuilder();
+      sb.append("entity-networks");
 
-    StringBuilder sb = new StringBuilder();
-    sb.append("entity-networks");
+      buildNetworkQueryString(sb,
+                              entityParamIds,
+                              entityListIds,
+                              maxDegrees,
+                              buildOut,
+                              maxEntities,
+                              forceMinimal,
+                              featureMode,
+                              withRaw);
 
-    buildNetworkQueryString(sb,
-                            entityParamIds,
-                            entityListIds,
-                            maxDegrees,
-                            buildOut,
-                            maxEntities,
-                            forceMinimal,
-                            featureMode,
-                            withRaw);
+      String uriText = this.formatServerUri(sb.toString());
+      UriInfo uriInfo = this.newProxyUriInfo(uriText);
 
-    String uriText = this.formatServerUri(sb.toString());
-    UriInfo uriInfo = this.newProxyUriInfo(uriText);
+      long before = System.currentTimeMillis();
 
-    long before = System.currentTimeMillis();
+      SzEntityNetworkResponse response
+          = this.entityGraphServices.getEntityNetwork(
+          formatIdentifierParam(entityParamIds),
+          formatIdentifierList(entityListIds),
+          (maxDegrees == null   ? DEFAULT_NETWORK_DEGREES : maxDegrees),
+          (buildOut == null     ? DEFAULT_BUILD_OUT : buildOut),
+          (maxEntities == null  ? DEFAULT_MAX_ENTITIES : maxEntities),
+          (forceMinimal == null ? false : forceMinimal),
+          (featureMode == null  ? WITH_DUPLICATES : featureMode),
+          (withRaw == null      ? false : withRaw),
+          uriInfo);
 
-    SzEntityNetworkResponse response
-        = this.entityGraphServices.getEntityNetwork(
-        formatIdentifierParam(entityParamIds),
-        formatIdentifierList(entityListIds),
-        (maxDegrees == null   ? DEFAULT_NETWORK_DEGREES : maxDegrees),
-        (buildOut == null     ? DEFAULT_BUILD_OUT : buildOut),
-        (maxEntities == null  ? DEFAULT_MAX_ENTITIES : maxEntities),
-        (forceMinimal == null ? false : forceMinimal),
-        (featureMode == null  ? WITH_DUPLICATES : featureMode),
-        (withRaw == null      ? false : withRaw),
-        uriInfo);
+      response.concludeTimers();
+      long after = System.currentTimeMillis();
 
-    response.concludeTimers();
-    long after = System.currentTimeMillis();
-
-    this.validateEntityNetworkResponse(
-        testInfo,
-        response,
-        uriText,
-        entityParamIds,
-        entityListIds,
-        (maxDegrees != null) ? maxDegrees : DEFAULT_NETWORK_DEGREES,
-        (buildOut != null) ? buildOut : DEFAULT_BUILD_OUT,
-        (maxEntities != null) ? maxEntities : DEFAULT_MAX_ENTITIES,
-        forceMinimal,
-        featureMode,
-        withRaw,
-        expectedPathCount,
-        expectedPaths,
-        expectedEntities,
-        before,
-        after);
+      this.validateEntityNetworkResponse(
+          testInfo,
+          response,
+          uriText,
+          entityParamIds,
+          entityListIds,
+          (maxDegrees != null) ? maxDegrees : DEFAULT_NETWORK_DEGREES,
+          (buildOut != null) ? buildOut : DEFAULT_BUILD_OUT,
+          (maxEntities != null) ? maxEntities : DEFAULT_MAX_ENTITIES,
+          forceMinimal,
+          featureMode,
+          withRaw,
+          expectedPathCount,
+          expectedPaths,
+          expectedEntities,
+          before,
+          after);
+    });
   }
 
   @ParameterizedTest
@@ -1511,62 +1511,62 @@ public class EntityGraphServicesTest extends AbstractServiceTest {
       List<List<SzRecordId>>   expectedPaths,
       Set<SzRecordId>          expectedEntities)
   {
-    String testInfo = "entityParam=[ " + entityParam
-        + " ], entityList=[ " + entityList
-        + " ], maxDegrees=[ " + maxDegrees
-        + " ], buildOut=[ " + buildOut
-        + " ], maxEntities=[ " + maxEntities
-        + " ], forceMinimal=[ " + forceMinimal
-        + " ], featureMode=[ " + featureMode
-        + " ], withRaw=[ " + withRaw + " ]";
+    this.performTest(() -> {
+      String testInfo = "entityParam=[ " + entityParam
+          + " ], entityList=[ " + entityList
+          + " ], maxDegrees=[ " + maxDegrees
+          + " ], buildOut=[ " + buildOut
+          + " ], maxEntities=[ " + maxEntities
+          + " ], forceMinimal=[ " + forceMinimal
+          + " ], featureMode=[ " + featureMode
+          + " ], withRaw=[ " + withRaw + " ]";
 
-    this.assumeNativeApiAvailable();
+      SzEntityIdentifiers entityParamIds
+          = this.normalizeIdentifiers(entityParam,true);
 
-    SzEntityIdentifiers entityParamIds
-        = this.normalizeIdentifiers(entityParam,true);
+      SzEntityIdentifiers entityListIds
+          = this.normalizeIdentifiers(entityList,true);
 
-    SzEntityIdentifiers entityListIds
-        = this.normalizeIdentifiers(entityList,true);
+      StringBuilder sb = new StringBuilder();
+      sb.append("entity-networks");
 
-    StringBuilder sb = new StringBuilder();
-    sb.append("entity-networks");
+      buildNetworkQueryString(sb,
+                              entityParamIds,
+                              entityListIds,
+                              maxDegrees,
+                              buildOut,
+                              maxEntities,
+                              forceMinimal,
+                              featureMode,
+                              withRaw);
 
-    buildNetworkQueryString(sb,
-                            entityParamIds,
-                            entityListIds,
-                            maxDegrees,
-                            buildOut,
-                            maxEntities,
-                            forceMinimal,
-                            featureMode,
-                            withRaw);
+      String uriText = this.formatServerUri(sb.toString());
 
-    String uriText = this.formatServerUri(sb.toString());
+      long before = System.currentTimeMillis();
 
-    long before = System.currentTimeMillis();
+      SzEntityNetworkResponse response = this.invokeServerViaHttp(
+          GET, uriText, SzEntityNetworkResponse.class);
+      response.concludeTimers();
+      long after = System.currentTimeMillis();
 
-    SzEntityNetworkResponse response = this.invokeServerViaHttp(
-        GET, uriText, SzEntityNetworkResponse.class);
-    response.concludeTimers();
-    long after = System.currentTimeMillis();
-
-    this.validateEntityNetworkResponse(
-        testInfo,
-        response,
-        uriText,
-        entityParamIds,
-        entityListIds,
-        (maxDegrees != null) ? maxDegrees : DEFAULT_NETWORK_DEGREES,
-        (buildOut != null) ? buildOut : DEFAULT_BUILD_OUT,
-        (maxEntities != null) ? maxEntities : DEFAULT_MAX_ENTITIES,
-        forceMinimal,
-        featureMode,
-        withRaw,
-        expectedPathCount,
-        expectedPaths,
-        expectedEntities,
-        before,
-        after);
+      this.validateEntityNetworkResponse(
+          testInfo,
+          response,
+          uriText,
+          entityParamIds,
+          entityListIds,
+          (maxDegrees != null) ? maxDegrees : DEFAULT_NETWORK_DEGREES,
+          (buildOut != null) ? buildOut : DEFAULT_BUILD_OUT,
+          (maxEntities != null) ? maxEntities : DEFAULT_MAX_ENTITIES,
+          forceMinimal,
+          featureMode,
+          withRaw,
+          expectedPathCount,
+          expectedPaths,
+          expectedEntities,
+          before,
+          after);
+    });
   }
 
   private void validateEntityNetworkResponse(

--- a/src/test/java/com/senzing/api/services/ExplicitConfigIdTest.java
+++ b/src/test/java/com/senzing/api/services/ExplicitConfigIdTest.java
@@ -44,138 +44,142 @@ public class ExplicitConfigIdTest extends AutoReinitializeTest
   }
 
   @Test public void getDataSourcesTest() {
-    this.assumeNativeApiAvailable();
-    final String newDataSource = "FOO";
-    String  uriText = this.formatServerUri("data-sources");
-    UriInfo uriInfo = this.newProxyUriInfo(uriText);
+    this.performTest(() -> {
+      final String newDataSource = "FOO";
+      String  uriText = this.formatServerUri("data-sources");
+      UriInfo uriInfo = this.newProxyUriInfo(uriText);
 
-    this.addDataSource(newDataSource);
+      this.addDataSource(newDataSource);
 
-    // now sleep for 1 second longer than the config refresh period
-    try {
-      Thread.sleep(SzApiServer.CONFIG_REFRESH_PERIOD + 1000L);
-    } catch (InterruptedException ignore) {
-      fail("Interrupted while sleeping and waiting for config refresh.");
-    }
+      // now sleep for 1 second longer than the config refresh period
+      try {
+        Thread.sleep(SzApiServer.CONFIG_REFRESH_PERIOD + 1000L);
+      } catch (InterruptedException ignore) {
+        fail("Interrupted while sleeping and waiting for config refresh.");
+      }
 
-    // now retry the request to get the data sources
-    long before = System.currentTimeMillis();
-    SzDataSourcesResponse response
-        = this.configServices.getDataSources(false, uriInfo);
-    response.concludeTimers();
-    long after = System.currentTimeMillis();
+      // now retry the request to get the data sources
+      long before = System.currentTimeMillis();
+      SzDataSourcesResponse response
+          = this.configServices.getDataSources(false, uriInfo);
+      response.concludeTimers();
+      long after = System.currentTimeMillis();
 
-    synchronized (this.expectedDataSources) {
-      this.validateDataSourcesResponse(response,
-                                       before,
-                                       after,
-                                       null,
-                                       INITIAL_DATA_SOURCES);
-    }
+      synchronized (this.expectedDataSources) {
+        this.validateDataSourcesResponse(response,
+                                         before,
+                                         after,
+                                         null,
+                                         INITIAL_DATA_SOURCES);
+      }
+    });
   }
 
   @Test public void getCurrentConfigTest() {
-    final String newDataSource = "PHOO";
-    this.assumeNativeApiAvailable();
-    String  uriText = this.formatServerUri("config/current");
-    UriInfo uriInfo = this.newProxyUriInfo(uriText);
+    this.performTest(() -> {
+      final String newDataSource = "PHOO";
+      String  uriText = this.formatServerUri("config/current");
+      UriInfo uriInfo = this.newProxyUriInfo(uriText);
 
-    this.addDataSource(newDataSource);
+      this.addDataSource(newDataSource);
 
-    // now sleep for 1 second longer than the config refresh period
-    try {
-      Thread.sleep(SzApiServer.CONFIG_REFRESH_PERIOD + 1000L);
-    } catch (InterruptedException ignore) {
-      fail("Interrupted while sleeping and waiting for config refresh.");
-    }
+      // now sleep for 1 second longer than the config refresh period
+      try {
+        Thread.sleep(SzApiServer.CONFIG_REFRESH_PERIOD + 1000L);
+      } catch (InterruptedException ignore) {
+        fail("Interrupted while sleeping and waiting for config refresh.");
+      }
 
-    long before = System.currentTimeMillis();
-    SzConfigResponse response
-        = this.configServices.getCurrentConfig(uriInfo);
-    response.concludeTimers();
-    long after = System.currentTimeMillis();
+      long before = System.currentTimeMillis();
+      SzConfigResponse response
+          = this.configServices.getCurrentConfig(uriInfo);
+      response.concludeTimers();
+      long after = System.currentTimeMillis();
 
-    synchronized (this.expectedDataSources) {
-      this.validateConfigResponse(response,
-                                  uriText,
-                                  before,
-                                  after,
-                                  INITIAL_DATA_SOURCES);
-    }
+      synchronized (this.expectedDataSources) {
+        this.validateConfigResponse(response,
+                                    uriText,
+                                    before,
+                                    after,
+                                    INITIAL_DATA_SOURCES);
+      }
+    });
   }
 
 
   @Test public void postRecordTest() {
-    final String newDataSource = "FOOX";
-    this.assumeNativeApiAvailable();
-    String  uriText = this.formatServerUri(
-        "data-sources/" + newDataSource + "/records");
-    UriInfo uriInfo = this.newProxyUriInfo(uriText);
+    this.performTest(() -> {
+      final String newDataSource = "FOOX";
+      String  uriText = this.formatServerUri(
+          "data-sources/" + newDataSource + "/records");
+      UriInfo uriInfo = this.newProxyUriInfo(uriText);
 
-    JsonObjectBuilder job = Json.createObjectBuilder();
-    job.add("NAME_FIRST", "Joe");
-    job.add("NAME_LAST", "Schmoe");
-    job.add("PHONE_NUMBER", "702-555-1212");
-    job.add("ADDR_FULL", "101 Main Street, Las Vegas, NV 89101");
-    JsonObject  jsonObject  = job.build();
-    String      jsonText    = JsonUtils.toJsonText(jsonObject);
+      JsonObjectBuilder job = Json.createObjectBuilder();
+      job.add("NAME_FIRST", "Joe");
+      job.add("NAME_LAST", "Schmoe");
+      job.add("PHONE_NUMBER", "702-555-1212");
+      job.add("ADDR_FULL", "101 Main Street, Las Vegas, NV 89101");
+      JsonObject  jsonObject  = job.build();
+      String      jsonText    = JsonUtils.toJsonText(jsonObject);
 
-    // add the data source (so it is there for retry)
-    this.addDataSource(newDataSource);
+      // add the data source (so it is there for retry)
+      this.addDataSource(newDataSource);
 
-    // now add the record -- this should succeed on retry
-    long before = System.currentTimeMillis();
-    try {
-      this.entityDataServices.loadRecord(
-          newDataSource, null, uriInfo, jsonText);
-      fail("Expected for data source \"" + newDataSource
-           + "\" to trigger a NotFoundException");
-    } catch (NotFoundException expected) {
-      SzErrorResponse response
-          = (SzErrorResponse) expected.getResponse().getEntity();
-      response.concludeTimers();
-      long after = System.currentTimeMillis();
+      // now add the record -- this should succeed on retry
+      long before = System.currentTimeMillis();
+      try {
+        this.entityDataServices.loadRecord(
+            newDataSource, null, uriInfo, jsonText);
+        fail("Expected for data source \"" + newDataSource
+                 + "\" to trigger a NotFoundException");
+      } catch (NotFoundException expected) {
+        SzErrorResponse response
+            = (SzErrorResponse) expected.getResponse().getEntity();
+        response.concludeTimers();
+        long after = System.currentTimeMillis();
 
-      this.validateBasics(
-          response, 404, POST, uriText, before, after);
-    }
+        this.validateBasics(
+            response, 404, POST, uriText, before, after);
+      }
+    });
   }
 
   @Test public void putRecordTest() {
-    final String recordId = "ABC123";
-    final String newDataSource = "PHOOX";
+    this.performTest(() -> {
+      final String recordId = "ABC123";
+      final String newDataSource = "PHOOX";
 
-    this.assumeNativeApiAvailable();
-    String  uriText = this.formatServerUri(
-        "data-sources/" + newDataSource + "/records/" + recordId);
-    UriInfo uriInfo = this.newProxyUriInfo(uriText);
+      String  uriText = this.formatServerUri(
+          "data-sources/" + newDataSource + "/records/" + recordId);
+      UriInfo uriInfo = this.newProxyUriInfo(uriText);
 
-    JsonObjectBuilder job = Json.createObjectBuilder();
-    job.add("NAME_FIRST", "John");
-    job.add("NAME_LAST", "Doe");
-    job.add("PHONE_NUMBER", "818-555-1313");
-    job.add("ADDR_FULL", "100 Main Street, Los Angeles, CA 90012");
-    JsonObject  jsonObject  = job.build();
-    String      jsonText    = JsonUtils.toJsonText(jsonObject);
+      JsonObjectBuilder job = Json.createObjectBuilder();
+      job.add("NAME_FIRST", "John");
+      job.add("NAME_LAST", "Doe");
+      job.add("PHONE_NUMBER", "818-555-1313");
+      job.add("ADDR_FULL", "100 Main Street, Los Angeles, CA 90012");
+      JsonObject  jsonObject  = job.build();
+      String      jsonText    = JsonUtils.toJsonText(jsonObject);
 
-    // add the data source (so it is there for retry)
-    this.addDataSource(newDataSource);
+      // add the data source (so it is there for retry)
+      this.addDataSource(newDataSource);
 
-    // now add the record -- this should succeed on retry
-    long before = System.currentTimeMillis();
-    try {
-      this.entityDataServices.loadRecord(
-          newDataSource, recordId, null, uriInfo, jsonText);
-      fail("Expected for data source \"" + newDataSource
-               + "\" to trigger a NotFoundException");
-    } catch (NotFoundException expected) {
-      SzErrorResponse response
-          = (SzErrorResponse) expected.getResponse().getEntity();
-      response.concludeTimers();
-      long after = System.currentTimeMillis();
+      // now add the record -- this should succeed on retry
+      long before = System.currentTimeMillis();
+      try {
+        this.entityDataServices.loadRecord(
+            newDataSource, recordId, null, uriInfo, jsonText);
+        fail("Expected for data source \"" + newDataSource
+                 + "\" to trigger a NotFoundException");
+      } catch (NotFoundException expected) {
+        SzErrorResponse response
+            = (SzErrorResponse) expected.getResponse().getEntity();
+        response.concludeTimers();
+        long after = System.currentTimeMillis();
 
-      this.validateBasics(
-          response, 404, PUT, uriText, before, after);
-    }
+        this.validateBasics(
+            response, 404, PUT, uriText, before, after);
+      }
+    });
   }
 }

--- a/src/test/java/com/senzing/api/services/ReadOnlyEntityDataWriteServicesTest.java
+++ b/src/test/java/com/senzing/api/services/ReadOnlyEntityDataWriteServicesTest.java
@@ -36,106 +36,110 @@ public class ReadOnlyEntityDataWriteServicesTest
   }
 
   @Test public void postRecordTest() {
-    this.assumeNativeApiAvailable();
-    String  uriText = this.formatServerUri(
-        "data-sources/" + TEST_DATA_SOURCE + "/records");
-    UriInfo uriInfo = this.newProxyUriInfo(uriText);
+    this.performTest(() -> {
+      String  uriText = this.formatServerUri(
+          "data-sources/" + TEST_DATA_SOURCE + "/records");
+      UriInfo uriInfo = this.newProxyUriInfo(uriText);
 
-    JsonObjectBuilder job = Json.createObjectBuilder();
-    job.add("NAME_FIRST", "Joe");
-    job.add("NAME_LAST", "Schmoe");
-    job.add("PHONE_NUMBER", "702-555-1212");
-    job.add("ADDR_FULL", "101 Main Street, Las Vegas, NV 89101");
-    JsonObject  jsonObject  = job.build();
-    String      jsonText    = JsonUtils.toJsonText(jsonObject);
+      JsonObjectBuilder job = Json.createObjectBuilder();
+      job.add("NAME_FIRST", "Joe");
+      job.add("NAME_LAST", "Schmoe");
+      job.add("PHONE_NUMBER", "702-555-1212");
+      job.add("ADDR_FULL", "101 Main Street, Las Vegas, NV 89101");
+      JsonObject  jsonObject  = job.build();
+      String      jsonText    = JsonUtils.toJsonText(jsonObject);
 
-    long before = System.currentTimeMillis();
-    try {
-      this.entityDataServices.loadRecord(
-          TEST_DATA_SOURCE, null, uriInfo, jsonText);
-      fail("Did not get expected 403 ForbiddenException in read-only mode");
+      long before = System.currentTimeMillis();
+      try {
+        this.entityDataServices.loadRecord(
+            TEST_DATA_SOURCE, null, uriInfo, jsonText);
+        fail("Did not get expected 403 ForbiddenException in read-only mode");
 
-    } catch (ForbiddenException expected) {
-      SzErrorResponse response
-          = (SzErrorResponse) expected.getResponse().getEntity();
-      response.concludeTimers();
-      long after = System.currentTimeMillis();
-      this.validateBasics(response, 403, POST, uriText, before, after);
-    }
+      } catch (ForbiddenException expected) {
+        SzErrorResponse response
+            = (SzErrorResponse) expected.getResponse().getEntity();
+        response.concludeTimers();
+        long after = System.currentTimeMillis();
+        this.validateBasics(response, 403, POST, uriText, before, after);
+      }
+    });
   }
 
   @Test public void postRecordTestViaHttp() {
-    this.assumeNativeApiAvailable();
-    String  uriText = this.formatServerUri(
-        "data-sources/" + TEST_DATA_SOURCE + "/records");
-    UriInfo uriInfo = this.newProxyUriInfo(uriText);
+    this.performTest(() -> {
+      String  uriText = this.formatServerUri(
+          "data-sources/" + TEST_DATA_SOURCE + "/records");
+      UriInfo uriInfo = this.newProxyUriInfo(uriText);
 
-    Map recordBody = new HashMap();
-    recordBody.put("NAME_FIRST", "Joanne");
-    recordBody.put("NAME_LAST", "Smith");
-    recordBody.put("PHONE_NUMBER", "212-555-1212");
-    recordBody.put("ADDR_FULL", "101 Fifth Ave, Las Vegas, NV 10018");
+      Map recordBody = new HashMap();
+      recordBody.put("NAME_FIRST", "Joanne");
+      recordBody.put("NAME_LAST", "Smith");
+      recordBody.put("PHONE_NUMBER", "212-555-1212");
+      recordBody.put("ADDR_FULL", "101 Fifth Ave, Las Vegas, NV 10018");
 
-    long before = System.currentTimeMillis();
-    SzErrorResponse response = this.invokeServerViaHttp(
-        POST, uriText, null, recordBody, SzErrorResponse.class);
-    response.concludeTimers();
-    long after = System.currentTimeMillis();
+      long before = System.currentTimeMillis();
+      SzErrorResponse response = this.invokeServerViaHttp(
+          POST, uriText, null, recordBody, SzErrorResponse.class);
+      response.concludeTimers();
+      long after = System.currentTimeMillis();
 
-    this.validateBasics(response, 403, POST, uriText, before, after);
+      this.validateBasics(response, 403, POST, uriText, before, after);
+    });
   }
 
   @Test public void putRecordTest() {
-    final String recordId = "ABC123";
+    this.performTest(() -> {
+      final String recordId = "ABC123";
 
-    this.assumeNativeApiAvailable();
-    String  uriText = this.formatServerUri(
-        "data-sources/" + TEST_DATA_SOURCE + "/records/" + recordId);
-    UriInfo uriInfo = this.newProxyUriInfo(uriText);
+      String  uriText = this.formatServerUri(
+          "data-sources/" + TEST_DATA_SOURCE + "/records/" + recordId);
+      UriInfo uriInfo = this.newProxyUriInfo(uriText);
 
-    JsonObjectBuilder job = Json.createObjectBuilder();
-    job.add("NAME_FIRST", "John");
-    job.add("NAME_LAST", "Doe");
-    job.add("PHONE_NUMBER", "818-555-1313");
-    job.add("ADDR_FULL", "100 Main Street, Los Angeles, CA 90012");
-    JsonObject  jsonObject  = job.build();
-    String      jsonText    = JsonUtils.toJsonText(jsonObject);
+      JsonObjectBuilder job = Json.createObjectBuilder();
+      job.add("NAME_FIRST", "John");
+      job.add("NAME_LAST", "Doe");
+      job.add("PHONE_NUMBER", "818-555-1313");
+      job.add("ADDR_FULL", "100 Main Street, Los Angeles, CA 90012");
+      JsonObject  jsonObject  = job.build();
+      String      jsonText    = JsonUtils.toJsonText(jsonObject);
 
-    long before = System.currentTimeMillis();
-    try {
-      this.entityDataServices.loadRecord(
-          TEST_DATA_SOURCE, recordId, null, uriInfo, jsonText);
+      long before = System.currentTimeMillis();
+      try {
+        this.entityDataServices.loadRecord(
+            TEST_DATA_SOURCE, recordId, null, uriInfo, jsonText);
 
-      fail("Did not get expected 403 ForbiddenException in read-only mode");
-    } catch (ForbiddenException expected) {
-      SzErrorResponse response
-          = (SzErrorResponse) expected.getResponse().getEntity();
-      response.concludeTimers();
-      long after = System.currentTimeMillis();
-      this.validateBasics(response, 403, PUT, uriText, before, after);
-    }
+        fail("Did not get expected 403 ForbiddenException in read-only mode");
+      } catch (ForbiddenException expected) {
+        SzErrorResponse response
+            = (SzErrorResponse) expected.getResponse().getEntity();
+        response.concludeTimers();
+        long after = System.currentTimeMillis();
+        this.validateBasics(response, 403, PUT, uriText, before, after);
+      }
+    });
   }
 
   @Test public void putRecordTestViaHttp() {
-    final String recordId = "XYZ456";
+    this.performTest(() -> {
+      final String recordId = "XYZ456";
 
-    this.assumeNativeApiAvailable();
-    String  uriText = this.formatServerUri(
-        "data-sources/" + TEST_DATA_SOURCE + "/records/" + recordId);
-    UriInfo uriInfo = this.newProxyUriInfo(uriText);
+      String  uriText = this.formatServerUri(
+          "data-sources/" + TEST_DATA_SOURCE + "/records/" + recordId);
+      UriInfo uriInfo = this.newProxyUriInfo(uriText);
 
-    Map recordBody = new HashMap();
-    recordBody.put("NAME_FIRST", "Jane");
-    recordBody.put("NAME_LAST", "Doe");
-    recordBody.put("PHONE_NUMBER", "818-555-1212");
-    recordBody.put("ADDR_FULL", "500 First Street, Los Angeles, CA 90033");
+      Map recordBody = new HashMap();
+      recordBody.put("NAME_FIRST", "Jane");
+      recordBody.put("NAME_LAST", "Doe");
+      recordBody.put("PHONE_NUMBER", "818-555-1212");
+      recordBody.put("ADDR_FULL", "500 First Street, Los Angeles, CA 90033");
 
-    long before = System.currentTimeMillis();
-    SzErrorResponse response = this.invokeServerViaHttp(
-        PUT, uriText, null, recordBody, SzErrorResponse.class);
-    response.concludeTimers();
-    long after = System.currentTimeMillis();
+      long before = System.currentTimeMillis();
+      SzErrorResponse response = this.invokeServerViaHttp(
+          PUT, uriText, null, recordBody, SzErrorResponse.class);
+      response.concludeTimers();
+      long after = System.currentTimeMillis();
 
-    this.validateBasics(response, 403, PUT, uriText, before, after);
+      this.validateBasics(response, 403, PUT, uriText, before, after);
+    });
   }
 }


### PR DESCRIPTION
- Updated dependency on FasterBind's Jackson library to version 2.9.10 to 
address security vulnerabilities.
- Added missing G2ConfigMgr.destroy() call in SzApiServer during shutdown
- Updated repository manager code used for JUnit tests to check for errors
when initializing the configuration manager and when creating the standard
configuration.
- Changes to Unit Tests:
    - Updated unit tests to preserve repos if any tests associated with that 
    repo failed.
    - Updated location of unit test entity repos to live in the 
    `./target/test-repos` directory during a Maven build and modified the 
    repo directory names to be based off the associated unit test name.
    - Updated the module name used for Senzing initialization in auto tests to 
    match the current auto test for post-failure diagnostic purposes.
    - Added forced preservation of unit test entity repos passing the 
    `-Dsenzing.preserve.test.repos=true` option to Maven.