### PR TITLE
Corrected dependency range for g2.jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <dependency>
      <groupId>com.senzing</groupId>
      <artifactId>g2</artifactId>
-       <version>[1.11.1-SNAPSHOT,2.0.0-SNAPSHOT)</version>
+       <version>[1.10.0-SNAPSHOT,2.0.0-SNAPSHOT)</version>
     </dependency>
     <dependency>
      <groupId>org.xerial</groupId>


### PR DESCRIPTION
Changed dependency range to:

       <version>[1.10.0-SNAPSHOT,2.0.0-SNAPSHOT)</version>
