### PR TITLE
Fix for tests failing instead of skipping if G2 native libraries are not installed

### DIFF
--- a/src/test/java/com/senzing/api/services/AbstractServiceTest.java
+++ b/src/test/java/com/senzing/api/services/AbstractServiceTest.java
@@ -65,7 +65,6 @@ public abstract class AbstractServiceTest {
       try {
         engineApi = new G2JNI();
       } catch (Throwable ignore) {
-        ignore.printStackTrace();
         // do nothing
       }
     } finally {
@@ -210,11 +209,11 @@ public abstract class AbstractServiceTest {
    * initialize and start the Senzing API Server.
    */
   protected void initializeTestEnvironment() {
+    if (!NATIVE_API_AVAILABLE) return;
     String moduleName = this.getModuleName("RepoMgr (create)");
     RepositoryManager.setThreadModuleName(moduleName);
     boolean concluded = false;
     try {
-      if (!NATIVE_API_AVAILABLE) return;
       RepositoryManager.createRepo(this.getRepositoryDirectory(), true);
       this.repoCreated = true;
 


### PR DESCRIPTION
Fixed it so tests skip again if the G2 native libraries are not installed.