### PR TITLE
Minor changes to error handling on bad command line & changelog update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.7] - 2019-09-30
+
+### Changes in 1.7.7
+
+- Fixed auto tests to skip instead of fail if Senzing native libraries are not
+available.
+- Fixed output when command line options do not provide initialization 
+parameters
+
 ## [1.7.6] - 2019-09-25
 
 ### Changes in 1.7.6

--- a/src/main/java/com/senzing/api/BuildInfo.java
+++ b/src/main/java/com/senzing/api/BuildInfo.java
@@ -7,7 +7,7 @@ import java.util.Properties;
 public class BuildInfo {
   public static final String MAVEN_VERSION;
 
-  public static final String REST_API_VERSION = "1.7.0";
+  public static final String REST_API_VERSION = "1.7.5";
 
   static {
     String resource = "/com/senzing/api/build-info.properties";

--- a/src/main/java/com/senzing/api/server/SzApiServer.java
+++ b/src/main/java/com/senzing/api/server/SzApiServer.java
@@ -883,10 +883,13 @@ public class SzApiServer implements SzApiProvider {
     Map<SzApiServerOption, ?> options = null;
     try {
       options = parseCommandLine(args);
+
     } catch (Exception e) {
-      System.err.println();
-      System.err.println(e.getMessage());
-      System.err.println();
+      if (!isLastLoggedException(e)) {
+        System.err.println();
+        System.err.println(e.getMessage());
+        System.err.println();
+      }
       System.err.println(SzApiServer.getUsageString());
       System.exit(1);
     }
@@ -1205,7 +1208,9 @@ public class SzApiServer implements SzApiProvider {
         this.initJson = JsonUtils.iniToJson(this.iniFile);
       }
     }
-    
+
+    this.configId = (Long) options.get(SzApiServerOption.CONFIG_ID);
+
     // validate the init JSON
     this.configType = getConfigType(this.moduleName, this.initJson);
     if (this.configType == null) {
@@ -1303,12 +1308,9 @@ public class SzApiServer implements SzApiProvider {
       pw.flush();
       String msg = sw.toString();
       System.err.println(msg);
-
     }
 
     this.allowedOrigins = (String) options.get(SzApiServerOption.ALLOWED_ORIGINS);
-
-    this.configId = (Long) options.get(SzApiServerOption.CONFIG_ID);
 
     this.baseUrl = "http://" + ipAddr.getHostAddress() + ":" + httpPort + "/";
 

--- a/src/main/java/com/senzing/cmdline/CommandLineUtilities.java
+++ b/src/main/java/com/senzing/cmdline/CommandLineUtilities.java
@@ -211,7 +211,7 @@ public class CommandLineUtilities {
         pw.flush();
         System.err.println();
         System.err.println(msg);
-        setLastLoggedException(new IllegalArgumentException(msg));
+        setLastLoggedAndThrow(new IllegalArgumentException(msg));
       }
     }
 


### PR DESCRIPTION
Modified CommandLineUtilities to do a "setLastLoggedAndThrow()" to throw an exception if a primary option is not provided.

Modified SzApiServer to NOT double-log exceptions that were already logged.

Updated CHANGELOG.md
