### PR TITLE
Updated Install Locations logic, uses environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.1] - 2020-03-30
+
+### Changed in 1.8.1
+
+- Supports environment variables for Senzing install locations
+    - SENZING_G2_DIR
+    - SENZING_DATA_DIR
+    - SENZING_ETC_DIR
+- Supports default to `/opt/senzing/data` as the support directory if the
+  versioned sub-directory is not found and the base directory contains expected
+  files.
+- Shortens the test time for TemporaryDataCacheTest 
+
 ## [1.8.0] - 2020-03-27
 
 ### Changed in 1.8.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
 ARG BASE_IMAGE=senzing/senzing-base:1.4.0
 ARG BASE_BUILDER_IMAGE=senzing/base-image-debian:1.0.3
+
 # -----------------------------------------------------------------------------
 # Stage: builder
 # -----------------------------------------------------------------------------
+
 FROM ${BASE_BUILDER_IMAGE} as builder
 
-# Set Shell to use for RUN commands in builder step
+# Set Shell to use for RUN commands in builder step.
 
 ENV REFRESHED_AT=2019-11-13
 
@@ -29,8 +31,9 @@ ENV LD_LIBRARY_PATH=${SENZING_ROOT}/g2/lib:${SENZING_ROOT}/g2/lib/debian
 
 COPY . /senzing-api-server
 
-WORKDIR /senzing-api-server
 # Run the "make" command to create the artifacts.
+
+WORKDIR /senzing-api-server
 
 RUN export SENZING_API_SERVER_JAR_VERSION=$(mvn "help:evaluate" -Dexpression=project.version -q -DforceStdout) \
  && make \
@@ -42,13 +45,14 @@ RUN export SENZING_API_SERVER_JAR_VERSION=$(mvn "help:evaluate" -Dexpression=pro
 # -----------------------------------------------------------------------------
 # Stage: Final
 # -----------------------------------------------------------------------------
+
 FROM ${BASE_IMAGE}
 
 ENV REFRESHED_AT=2020-01-29
 
 LABEL Name="senzing/senzing-api-server" \
       Maintainer="support@senzing.com" \
-      Version="1.7.10"
+      Version="1.8.1"
 
 HEALTHCHECK CMD ["/app/healthcheck.sh"]
 
@@ -63,13 +67,13 @@ RUN apt update \
       software-properties-common \
  && rm -rf /var/lib/apt/lists/*
 
-# Install Java-8 - To be removed after Senzing API server supports Java 11
-# Once fixed, add "default-jdk" to "apt install ..."
+# Install Java-11.
 
 RUN wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | apt-key add - \
  && add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/ \
  && apt update \
- && apt -y install adoptopenjdk-8-hotspot
+ && apt install -y adoptopenjdk-11-hotspot \
+ && rm -rf /var/lib/apt/lists/*
 
 # Service exposed on port 8080.
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.senzing</groupId>
   <artifactId>senzing-api-server</artifactId>
   <packaging>jar</packaging>
-  <version>1.8.0</version>
+  <version>1.8.1</version>
   <name>senzing-api-server</name>
   <url>http://maven.apache.org</url>
   <dependencies>

--- a/src/test/java/com/senzing/io/TemporaryDataCacheTest.java
+++ b/src/test/java/com/senzing/io/TemporaryDataCacheTest.java
@@ -43,7 +43,7 @@ public class TemporaryDataCacheTest {
       File testFile = File.createTempFile("test-file-", ".dat");
       this.testFiles.add(testFile);
       exponent = index + Math.max(0, index - 1);
-      int fileSize = (int) Math.pow(28.0, (double) exponent);
+      int fileSize = (int) Math.pow(25.0, (double) exponent);
 
       try (FileOutputStream     fos = new FileOutputStream(testFile);
            BufferedOutputStream bos = new BufferedOutputStream(fos, 8192))


### PR DESCRIPTION
- Supports environment variables for Senzing install locations
    - SENZING_G2_DIR
    - SENZING_DATA_DIR
    - SENZING_ETC_DIR
- Supports default to `/opt/senzing/data` as the support directory if the versioned sub-directory is not found and the base directory contains expected files.
- Shortens the test time for TemporaryDataCacheTest 
- Updated Dockerfile for Java 11
