### PR TITLE
Moving test to a daily run

### DIFF
--- a/.github/workflows/cd-daily-cron-test-debian-build.yml
+++ b/.github/workflows/cd-daily-cron-test-debian-build.yml
@@ -2,7 +2,7 @@ name: Cron Schedule 3 hr Test Java API Server Build on Debian
 
 on:
   schedule:
-    - cron: '0 */3 * * *'
+    - cron: '0 0 * * *'
 
 
 jobs:


### PR DESCRIPTION
Make the debian build test run every day instead of every 3 hours.