### PR TITLE
Minor changes for version 2.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.7.2] - 2021-08-20
+
+### Changed in 2.7.2
+
+- Minor bug fix for internal CommandLineUtilities class to recognize environment
+  variables for "base" options.  This allows others to extends the Senzing API
+  Server code with new options but still have the environment variables from the
+  base options be recognized (required for `Senzing/senzing-poc-server`).
+
 ## [2.7.1] - 2021-08-16
 
 ### Changed in 2.7.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ ENV REFRESHED_AT=2021-07-14
 
 LABEL Name="senzing/senzing-api-server" \
       Maintainer="support@senzing.com" \
-      Version="2.7.1"
+      Version="2.7.2"
 
 HEALTHCHECK CMD ["/app/healthcheck.sh"]
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.senzing</groupId>
   <artifactId>senzing-api-server</artifactId>
   <packaging>jar</packaging>
-  <version>2.7.1</version>
+  <version>2.7.2</version>
   <name>senzing-api-server</name>
   <url>http://maven.apache.org</url>
   <dependencies>

--- a/src/main/java/com/senzing/cmdline/CommandLineUtilities.java
+++ b/src/main/java/com/senzing/cmdline/CommandLineUtilities.java
@@ -411,6 +411,30 @@ public class CommandLineUtilities {
   }
 
   /**
+   * Populates the options chain for the specified command line option class in
+   * the specified {@link Set}.
+   *
+   * @param set The {@link} set to populate.
+   * @param enumClass The starting class for the options chain.
+   */
+  private static <T extends Enum<T> & CommandLineOption<T>>
+  void populateOptionsChain(Set<CommandLineOption>  set,
+                            Class<T>                enumClass)
+  {
+    if (enumClass == null) return;
+    EnumSet<T> enumSet = EnumSet.allOf(enumClass);
+    Class baseType = null;
+    for (T option : enumSet) {
+      set.add((CommandLineOption) option);
+      if (baseType == null) baseType = option.getBaseOptionType();
+    }
+
+    if (baseType != null) {
+      populateOptionsChain(set, baseType);
+    }
+  }
+
+  /**
    * Validates the specified {@link Set} of specified {@link CommandLineOption}
    * instances and ensures that they logically make sense together.  This
    * checks for the existing of at least one primary option (if primary options
@@ -953,7 +977,7 @@ public class CommandLineUtilities {
   }
 
   /**
-   * Checka for command-line option values in the environment.
+   * Check for command-line option values in the environment.
    *
    */
   private static <T extends Enum<T> & CommandLineOption<T>> void
@@ -961,7 +985,8 @@ public class CommandLineUtilities {
                      ParameterProcessor                       processor,
                      Map<CommandLineOption, CommandLineValue> optionValues)
   {
-    Set<T> options = EnumSet.allOf(enumClass);
+    Set<CommandLineOption> options = new LinkedHashSet<>();
+    populateOptionsChain(options, enumClass);
 
     processEnvironment(options,
                        processor,


### PR DESCRIPTION
Version 2.7.2 resolves a minor issue in CommandLineUtilities class so repos that extend Senzing API Server and build on it and add new command-line options while still recognizing the environment variables from the Senzing API Server base options as well.

No changes to any runtime functionality -- this only affects repos that leverage the command-line option extension mechanism provided in the code base.
