### PR TITLE
Issue 260.ron.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.8.2] - 2022-01-25
+
+### Changed in 2.8.2
+
+- Updated Docker image with new version of Debian
+- Removed dependence on senzing-base image
+
 ## [2.8.1] - 2022-01-13
 
 ### Changed in 2.8.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,14 +30,10 @@ RUN export SENZING_API_SERVER_VERSION=$(mvn "help:evaluate" -Dexpression=project
       && make package \
       && cp /senzing-api-server/target/senzing-api-server-${SENZING_API_SERVER_VERSION}.jar "/senzing-api-server.jar"
 
-# Install packages via apt.
-
-RUN apt update \
-      && apt -y install \
-      wget \
-      && rm -rf /var/lib/apt/lists/*
+# Grab a gpg key for our final stage to install the JDK
 
 RUN wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public > /gpg.key
+
 # -----------------------------------------------------------------------------
 # Stage: Final
 # -----------------------------------------------------------------------------
@@ -60,13 +56,13 @@ USER root
 
 RUN apt update \
       && apt -y install \
-      gnupg \
+      gnupg2 \
       software-properties-common \
       && rm -rf /var/lib/apt/lists/*
 
 # Install Java-11.
 COPY --from=builder "/gpg.key" "gpg.key"
-# RUN wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | apt-key add - \
+
 RUN cat gpg.key | apt-key add - \
       && add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/ \
       && apt update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # ARG BASE_IMAGE=senzing/senzing-base:1.6.4
-ARG BASE_IMAGE=debian:11.2@sha256:084cbaefbcd3b9a230fe2a65ab8cc0ddfc01576176136d66f21060647e6aa124
+ARG BASE_IMAGE=debian:11.2@sha256:2906804d2a64e8a13a434a1a127fe3f6a28bf7cf3696be4223b06276f32f1f2d
 ARG BASE_BUILDER_IMAGE=senzing/base-image-debian:1.0.7
 
 # -----------------------------------------------------------------------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=debian:11.2-slim@sha256:b0d53c872fd640c2af2608ba1e693cfc7dedea30abcd8f584b23d583ec6dadc7
+ARG BASE_IMAGE=debian:11.2-slim@sha256:4c25ffa6ef572cf0d57da8c634769a08ae94529f7de5be5587ec8ce7b9b50f9c
 ARG BASE_BUILDER_IMAGE=senzing/base-image-debian:1.0.7
 
 # -----------------------------------------------------------------------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,7 @@ USER root
 RUN apt update \
       && apt -y install \
       gnupg2 \
+      postgresql-client \
       software-properties-common \
       && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG BASE_BUILDER_IMAGE=senzing/base-image-debian:1.0.7
 
 FROM ${BASE_BUILDER_IMAGE} as builder
 
-ENV REFRESHED_AT=2022-01-06
+ENV REFRESHED_AT=2022-01-25
 
 LABEL Name="senzing/senzing-api-server-builder" \
       Maintainer="support@senzing.com" \
@@ -39,11 +39,11 @@ RUN wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public > /
 
 FROM ${BASE_IMAGE}
 
-ENV REFRESHED_AT=2022-01-06
+ENV REFRESHED_AT=2022-01-25
 
 LABEL Name="senzing/senzing-api-server" \
       Maintainer="support@senzing.com" \
-      Version="2.8.1"
+      Version="2.8.2"
 
 HEALTHCHECK CMD ["/app/healthcheck.sh"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -73,6 +73,18 @@ RUN cat gpg.key | apt-key add - \
 
 COPY ./rootfs /
 
+# Downgrade to TLSv1.1
+
+RUN sed -i 's/TLSv1.2/TLSv1.1/g' /etc/ssl/openssl.cnf
+
+# Set environment variables for root.
+
+ENV LD_LIBRARY_PATH=/opt/senzing/g2/lib:/opt/senzing/g2/lib/debian:/opt/IBM/db2/clidriver/lib
+ENV ODBCSYSINI=/etc/opt/senzing
+ENV PATH=${PATH}:/opt/senzing/g2/python:/opt/IBM/db2/clidriver/adm:/opt/IBM/db2/clidriver/bin
+ENV PYTHONPATH=/opt/senzing/g2/python
+ENV SENZING_ETC_PATH=/etc/opt/senzing
+
 # Service exposed on port 8080.
 
 EXPOSE 8080
@@ -84,6 +96,14 @@ COPY --from=builder "/senzing-api-server.jar" "/app/senzing-api-server.jar"
 # Make non-root container.
 
 USER 1001
+
+# Set environment variables for USER 1001.
+
+ENV LD_LIBRARY_PATH=/opt/senzing/g2/lib:/opt/senzing/g2/lib/debian:/opt/IBM/db2/clidriver/lib
+ENV ODBCSYSINI=/etc/opt/senzing
+ENV PATH=${PATH}:/opt/senzing/g2/python:/opt/IBM/db2/clidriver/adm:/opt/IBM/db2/clidriver/bin
+ENV PYTHONPATH=/opt/senzing/g2/python
+ENV SENZING_ETC_PATH=/etc/opt/senzing
 
 # Runtime execution.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,3 @@
-# ARG BASE_IMAGE=senzing/senzing-base:1.6.4
 ARG BASE_IMAGE=debian:11.2@sha256:2906804d2a64e8a13a434a1a127fe3f6a28bf7cf3696be4223b06276f32f1f2d
 ARG BASE_BUILDER_IMAGE=senzing/base-image-debian:1.0.7
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=debian:11.2@sha256:2906804d2a64e8a13a434a1a127fe3f6a28bf7cf3696be4223b06276f32f1f2d
+ARG BASE_IMAGE=debian:11.2-slim@sha256:b0d53c872fd640c2af2608ba1e693cfc7dedea30abcd8f584b23d583ec6dadc7
 ARG BASE_BUILDER_IMAGE=senzing/base-image-debian:1.0.7
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
# Pull request questions

## Which issue does this address

Issue number: #260

## Why was change needed

To improve the attack surface of the Api Server image.

## What does change improve

Updated to Debian:11.2-slim which fixed many vulnerabilities and is ~100MB smaller than a Debian:11.2 based image.

In version 2.8.1 Snyk reports that it checked 414 dependencies for known issues and found 240 issues.
In the updated version Snyk reports that it checked 223 dependencies for known issues and found 80 issues.

EDIT:  on 27 Jan 2022 there was a new release of Debian 11.2 and a new vulnerabilities database the version we were using 2 days ago now has 85 issues and the new version has 83.  

Removal of installed but unused packages accounts for many of the dependencies.  Update of the OS brings down the number of issues found.

Below is a list of the 8 Critical and 8 High vulnerabilities that Snyk found.  As of 25 Jan 2022, there are no fixes available for any of them.

EDIT: on 27 Jan 2022, updated to the new release of Debian which brings us to 8 Critical still and 10 High vulnerabilities which is the same as what the Debian release from 25 Jan gives us with the new vulnerabilities database in Snyk.

### Critical and High Vulnerabilities:
```
✗ High severity vulnerability found in perl/perl-base
  Description: Improper Verification of Cryptographic Signature
  Info: https://snyk.io/vuln/SNYK-DEBIAN11-PERL-1925976
  Introduced through: meta-common-packages@meta
  From: meta-common-packages@meta > perl/perl-base@5.32.1-4+deb11u2
  Image layer: Introduced by your base image (debian:11.2)

✗ High severity vulnerability found in libgcrypt20
  Description: Information Exposure
  Info: https://snyk.io/vuln/SNYK-DEBIAN11-LIBGCRYPT20-1297892
  Introduced through: meta-common-packages@meta
  From: meta-common-packages@meta > libgcrypt20@1.8.7-6
  Image layer: Introduced by your base image (debian:11.2)

✗ High severity vulnerability found in expat/libexpat1
  Description: Resource Exhaustion
  Info: https://snyk.io/vuln/SNYK-DEBIAN11-EXPAT-2329086
  Introduced through: dbus@1.12.20-2, adoptopenjdk-11-hotspot@11.0.11+9-3, packagekit@1.2.2-2, software-properties/software-properties-common@0.96.20.2-2.1
  From: dbus@1.12.20-2 > expat/libexpat1@2.2.10-2
  From: adoptopenjdk-11-hotspot@11.0.11+9-3 > fontconfig/libfontconfig1@2.13.1-4.2 > expat/libexpat1@2.2.10-2
  From: packagekit@1.2.2-2 > policykit-1@0.105-31 > expat/libexpat1@2.2.10-2
  and 1 more...
  Image layer: 'RUN /bin/sh -c cat gpg.key | apt-key add -       && add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/       && apt update       && apt install -y adoptopenjdk-11-hotspot       && rm -rf /var/lib/apt/lists/*       && rm -f gpg.key '

✗ High severity vulnerability found in expat/libexpat1
  Description: Integer Overflow or Wraparound
  Info: https://snyk.io/vuln/SNYK-DEBIAN11-EXPAT-2330887
  Introduced through: dbus@1.12.20-2, adoptopenjdk-11-hotspot@11.0.11+9-3, packagekit@1.2.2-2, software-properties/software-properties-common@0.96.20.2-2.1
  From: dbus@1.12.20-2 > expat/libexpat1@2.2.10-2
  From: adoptopenjdk-11-hotspot@11.0.11+9-3 > fontconfig/libfontconfig1@2.13.1-4.2 > expat/libexpat1@2.2.10-2
  From: packagekit@1.2.2-2 > policykit-1@0.105-31 > expat/libexpat1@2.2.10-2
  and 1 more...
  Image layer: 'RUN /bin/sh -c cat gpg.key | apt-key add -       && add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/       && apt update       && apt install -y adoptopenjdk-11-hotspot       && rm -rf /var/lib/apt/lists/*       && rm -f gpg.key '

✗ High severity vulnerability found in expat/libexpat1
  Description: Integer Overflow or Wraparound
  Info: https://snyk.io/vuln/SNYK-DEBIAN11-EXPAT-2331798
  Introduced through: dbus@1.12.20-2, adoptopenjdk-11-hotspot@11.0.11+9-3, packagekit@1.2.2-2, software-properties/software-properties-common@0.96.20.2-2.1
  From: dbus@1.12.20-2 > expat/libexpat1@2.2.10-2
  From: adoptopenjdk-11-hotspot@11.0.11+9-3 > fontconfig/libfontconfig1@2.13.1-4.2 > expat/libexpat1@2.2.10-2
  From: packagekit@1.2.2-2 > policykit-1@0.105-31 > expat/libexpat1@2.2.10-2
  and 1 more...
  Image layer: 'RUN /bin/sh -c cat gpg.key | apt-key add -       && add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/       && apt update       && apt install -y adoptopenjdk-11-hotspot       && rm -rf /var/lib/apt/lists/*       && rm -f gpg.key '

✗ High severity vulnerability found in expat/libexpat1
  Description: Integer Overflow or Wraparound
  Info: https://snyk.io/vuln/SNYK-DEBIAN11-EXPAT-2331806
  Introduced through: dbus@1.12.20-2, adoptopenjdk-11-hotspot@11.0.11+9-3, packagekit@1.2.2-2, software-properties/software-properties-common@0.96.20.2-2.1
  From: dbus@1.12.20-2 > expat/libexpat1@2.2.10-2
  From: adoptopenjdk-11-hotspot@11.0.11+9-3 > fontconfig/libfontconfig1@2.13.1-4.2 > expat/libexpat1@2.2.10-2
  From: packagekit@1.2.2-2 > policykit-1@0.105-31 > expat/libexpat1@2.2.10-2
  and 1 more...
  Image layer: 'RUN /bin/sh -c cat gpg.key | apt-key add -       && add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/       && apt update       && apt install -y adoptopenjdk-11-hotspot       && rm -rf /var/lib/apt/lists/*       && rm -f gpg.key '

✗ High severity vulnerability found in expat/libexpat1
  Description: Integer Overflow or Wraparound
  Info: https://snyk.io/vuln/SNYK-DEBIAN11-EXPAT-2331819
  Introduced through: dbus@1.12.20-2, adoptopenjdk-11-hotspot@11.0.11+9-3, packagekit@1.2.2-2, software-properties/software-properties-common@0.96.20.2-2.1
  From: dbus@1.12.20-2 > expat/libexpat1@2.2.10-2
  From: adoptopenjdk-11-hotspot@11.0.11+9-3 > fontconfig/libfontconfig1@2.13.1-4.2 > expat/libexpat1@2.2.10-2
  From: packagekit@1.2.2-2 > policykit-1@0.105-31 > expat/libexpat1@2.2.10-2
  and 1 more...
  Image layer: 'RUN /bin/sh -c cat gpg.key | apt-key add -       && add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/       && apt update       && apt install -y adoptopenjdk-11-hotspot       && rm -rf /var/lib/apt/lists/*       && rm -f gpg.key '

✗ High severity vulnerability found in curl/libcurl3-gnutls
  Description: Cleartext Transmission of Sensitive Information
  Info: https://snyk.io/vuln/SNYK-DEBIAN11-CURL-1585138
  Introduced through: appstream/libappstream4@0.14.4-1, software-properties/software-properties-common@0.96.20.2-2.1
  From: appstream/libappstream4@0.14.4-1 > curl/libcurl3-gnutls@7.74.0-1.3+deb11u1
  From: software-properties/software-properties-common@0.96.20.2-2.1 > software-properties/python3-software-properties@0.96.20.2-2.1 > pycurl/python3-pycurl@7.43.0.6-5 > curl/libcurl3-gnutls@7.74.0-1.3+deb11u1
  Image layer: Introduced by your base image (debian:11.2)

✗ Critical severity vulnerability found in python3.9/libpython3.9-stdlib
  Description: Improper Input Validation
  Info: https://snyk.io/vuln/SNYK-DEBIAN11-PYTHON39-1290158
  Introduced through: software-properties/software-properties-common@0.96.20.2-2.1
  From: software-properties/software-properties-common@0.96.20.2-2.1 > python3-defaults/python3@3.9.2-3 > python3-defaults/libpython3-stdlib@3.9.2-3 > python3.9/libpython3.9-stdlib@3.9.2-1
  From: software-properties/software-properties-common@0.96.20.2-2.1 > python3-defaults/python3@3.9.2-3 > python3.9@3.9.2-1 > python3.9/libpython3.9-stdlib@3.9.2-1
  From: software-properties/software-properties-common@0.96.20.2-2.1 > python3-defaults/python3@3.9.2-3 > python3-defaults/python3-minimal@3.9.2-3 > python3.9/python3.9-minimal@3.9.2-1
  and 4 more...
  Image layer: Introduced by your base image (debian:11.2)

✗ Critical severity vulnerability found in glibc/libc-bin
  Description: Use After Free
  Info: https://snyk.io/vuln/SNYK-DEBIAN11-GLIBC-1296898
  Introduced through: glibc/libc-bin@2.31-13+deb11u2, meta-common-packages@meta
  From: glibc/libc-bin@2.31-13+deb11u2
  From: meta-common-packages@meta > glibc/libc6@2.31-13+deb11u2
  Image layer: Introduced by your base image (debian:11.2)

✗ Critical severity vulnerability found in glibc/libc-bin
  Description: Buffer Overflow
  Info: https://snyk.io/vuln/SNYK-DEBIAN11-GLIBC-2340908
  Introduced through: glibc/libc-bin@2.31-13+deb11u2, meta-common-packages@meta
  From: glibc/libc-bin@2.31-13+deb11u2
  From: meta-common-packages@meta > glibc/libc6@2.31-13+deb11u2
  Image layer: Introduced by your base image (debian:11.2)

✗ Critical severity vulnerability found in glibc/libc-bin
  Description: Buffer Overflow
  Info: https://snyk.io/vuln/SNYK-DEBIAN11-GLIBC-2340922
  Introduced through: glibc/libc-bin@2.31-13+deb11u2, meta-common-packages@meta
  From: glibc/libc-bin@2.31-13+deb11u2
  From: meta-common-packages@meta > glibc/libc6@2.31-13+deb11u2
  Image layer: Introduced by your base image (debian:11.2)

✗ Critical severity vulnerability found in expat/libexpat1
  Description: Integer Overflow or Wraparound
  Info: https://snyk.io/vuln/SNYK-DEBIAN11-EXPAT-2331802
  Introduced through: dbus@1.12.20-2, adoptopenjdk-11-hotspot@11.0.11+9-3, packagekit@1.2.2-2, software-properties/software-properties-common@0.96.20.2-2.1
  From: dbus@1.12.20-2 > expat/libexpat1@2.2.10-2
  From: adoptopenjdk-11-hotspot@11.0.11+9-3 > fontconfig/libfontconfig1@2.13.1-4.2 > expat/libexpat1@2.2.10-2
  From: packagekit@1.2.2-2 > policykit-1@0.105-31 > expat/libexpat1@2.2.10-2
  and 1 more...
  Image layer: 'RUN /bin/sh -c cat gpg.key | apt-key add -       && add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/       && apt update       && apt install -y adoptopenjdk-11-hotspot       && rm -rf /var/lib/apt/lists/*       && rm -f gpg.key '

✗ Critical severity vulnerability found in expat/libexpat1
  Description: Integer Overflow or Wraparound
  Info: https://snyk.io/vuln/SNYK-DEBIAN11-EXPAT-2331808
  Introduced through: dbus@1.12.20-2, adoptopenjdk-11-hotspot@11.0.11+9-3, packagekit@1.2.2-2, software-properties/software-properties-common@0.96.20.2-2.1
  From: dbus@1.12.20-2 > expat/libexpat1@2.2.10-2
  From: adoptopenjdk-11-hotspot@11.0.11+9-3 > fontconfig/libfontconfig1@2.13.1-4.2 > expat/libexpat1@2.2.10-2
  From: packagekit@1.2.2-2 > policykit-1@0.105-31 > expat/libexpat1@2.2.10-2
  and 1 more...
  Image layer: 'RUN /bin/sh -c cat gpg.key | apt-key add -       && add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/       && apt update       && apt install -y adoptopenjdk-11-hotspot       && rm -rf /var/lib/apt/lists/*       && rm -f gpg.key '

✗ Critical severity vulnerability found in expat/libexpat1
  Description: Integer Overflow or Wraparound
  Info: https://snyk.io/vuln/SNYK-DEBIAN11-EXPAT-2331811
  Introduced through: dbus@1.12.20-2, adoptopenjdk-11-hotspot@11.0.11+9-3, packagekit@1.2.2-2, software-properties/software-properties-common@0.96.20.2-2.1
  From: dbus@1.12.20-2 > expat/libexpat1@2.2.10-2
  From: adoptopenjdk-11-hotspot@11.0.11+9-3 > fontconfig/libfontconfig1@2.13.1-4.2 > expat/libexpat1@2.2.10-2
  From: packagekit@1.2.2-2 > policykit-1@0.105-31 > expat/libexpat1@2.2.10-2
  and 1 more...
  Image layer: 'RUN /bin/sh -c cat gpg.key | apt-key add -       && add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/       && apt update       && apt install -y adoptopenjdk-11-hotspot       && rm -rf /var/lib/apt/lists/*       && rm -f gpg.key '

✗ Critical severity vulnerability found in curl/libcurl3-gnutls
  Description: Double Free
  Info: https://snyk.io/vuln/SNYK-DEBIAN11-CURL-1585150
  Introduced through: appstream/libappstream4@0.14.4-1, software-properties/software-properties-common@0.96.20.2-2.1
  From: appstream/libappstream4@0.14.4-1 > curl/libcurl3-gnutls@7.74.0-1.3+deb11u1
  From: software-properties/software-properties-common@0.96.20.2-2.1 > software-properties/python3-software-properties@0.96.20.2-2.1 > pycurl/python3-pycurl@7.43.0.6-5 > curl/libcurl3-gnutls@7.74.0-1.3+deb11u1
  Image layer: Introduced by your base image (debian:11.2)

```