### PR TITLE
Version 2.8.4: Updates to pom.xml to exclude beta 3.x dependencies of Senzing artifacts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.8.4] - 2022-03-07
+
+### Added to 2.8.4
+
+- Updates to `pom.xml` to prevent pulling beta `3.0.0` versions of 
+  `senzing-sdk-java` and `senzing-commons-java` via the Maven dependency range.
+
 ## [2.8.3] - 2022-02-04
 
 ### Changed in 2.8.3

--- a/pom.xml
+++ b/pom.xml
@@ -4,19 +4,19 @@
   <groupId>com.senzing</groupId>
   <artifactId>senzing-api-server</artifactId>
   <packaging>jar</packaging>
-  <version>2.8.3</version>
+  <version>2.8.4</version>
   <name>senzing-api-server</name>
   <url>http://maven.apache.org</url>
   <dependencies>
     <dependency>
      <groupId>com.senzing</groupId>
      <artifactId>g2</artifactId>
-       <version>[2.0.0-SNAPSHOT,3.0.0-SNAPSHOT)</version>
+       <version>[2.0.0-SNAPSHOT,2.999.999]</version>
     </dependency>
     <dependency>
       <groupId>com.senzing</groupId>
       <artifactId>senzing-commons</artifactId>
-      <version>[2.0.0-SNAPSHOT,3.0.0-SNAPSHOT)</version>
+      <version>[2.0.0-SNAPSHOT,2.999.999]</version>
     </dependency>
     <dependency>
      <groupId>org.xerial</groupId>


### PR DESCRIPTION
Updates to `pom.xml` to prevent pulling beta `3.0.0` versions of `senzing-sdk-java` and `senzing-commons-java` via the Maven dependency range.