### PR TITLE
Version 3.3.0 -- some missed dependency updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,12 +11,12 @@
     <dependency>
      <groupId>com.senzing</groupId>
      <artifactId>g2</artifactId>
-       <version>[3.0.0, 3.999.999)</version>
+       <version>[3.0.0, 3.9999.9999)</version>
     </dependency>
     <dependency>
       <groupId>com.senzing</groupId>
       <artifactId>senzing-commons</artifactId>
-      <version>[3.0.0, 3.999.999)</version>
+      <version>[3.0.0, 3.9999.9999)</version>
     </dependency>
     <dependency>
      <groupId>org.xerial</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -108,27 +108,27 @@
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-json-jackson</artifactId>
-      <version>2.35</version>
+      <version>2.36</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-multipart</artifactId>
-      <version>2.35</version>
+      <version>2.36</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.inject</groupId>
       <artifactId>jersey-hk2</artifactId>
-      <version>2.35</version>
+      <version>2.36</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.13.2</version>
+      <version>2.13.3</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.13.2.1</version>
+      <version>2.13.3</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
When updating Jersey to version 2.35 and Jackson to 2.13.3, some of the related dependencies also needed their versions
bumped to those latest versions.