### PR TITLE
Updated pom.xml and to use latest senzing-rest-api-specification

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.senzing</groupId>
   <artifactId>senzing-api-server</artifactId>
   <packaging>jar</packaging>
-  <version>3.2.0</version>
+  <version>3.3.0</version>
   <name>senzing-api-server</name>
   <url>http://maven.apache.org</url>
   <dependencies>
@@ -21,7 +21,7 @@
     <dependency>
      <groupId>org.xerial</groupId>
      <artifactId>sqlite-jdbc</artifactId>
-       <version>3.30.1</version>
+       <version>3.39.2.0</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>


### PR DESCRIPTION
- pom.xml version updated to 3.3.0
- senzing-rest-api-specification 3.2.0 latest release with updated documentation now being used
- updated sqlite-jdbc dependency to version 3.39.2.0
