### PR TITLE
V3.3.1 Release: Updated to latest senzing-commons-java to resolve environment variable fallback issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.1] - 2022-08-23
+
+### Changed in 3.3.1
+
+- Updated dependency on `Senzing/senzing-commons-java` to a minimum version of
+  `3.0.1` to resolve issue with environment variable fallbacks for primary  
+  options which typically lack dependencies.
+
 ## [3.3.0] - 2022-08-17
 
 ### Changed in 3.3.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV REFRESHED_AT=2022-08-12
 
 LABEL Name="senzing/senzing-api-server-builder" \
       Maintainer="support@senzing.com" \
-      Version="3.3.0"
+      Version="3.3.1"
 
 # Set environment variables.
 
@@ -43,7 +43,7 @@ ENV REFRESHED_AT=2022-08-12
 
 LABEL Name="senzing/senzing-api-server" \
       Maintainer="support@senzing.com" \
-      Version="3.3.0"
+      Version="3.3.1"
 
 HEALTHCHECK CMD ["/app/healthcheck.sh"]
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.senzing</groupId>
   <artifactId>senzing-api-server</artifactId>
   <packaging>jar</packaging>
-  <version>3.3.0</version>
+  <version>3.3.1</version>
   <name>senzing-api-server</name>
   <url>http://maven.apache.org</url>
   <dependencies>
@@ -16,7 +16,7 @@
     <dependency>
       <groupId>com.senzing</groupId>
       <artifactId>senzing-commons</artifactId>
-      <version>[3.0.0, 3.9999.9999)</version>
+      <version>[3.0.1, 3.9999.9999)</version>
     </dependency>
     <dependency>
      <groupId>org.xerial</groupId>


### PR DESCRIPTION
Updated dependency on `Senzing/senzing-commons-java` to a minimum version of `3.0.1` to resolve issue with environment variable fallbacks for primary options which typically lack dependencies.