### PR TITLE
Bind to all interfaces when in a docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -111,4 +111,4 @@ ENV PATH=${PATH}:/opt/senzing/g2/python:/opt/IBM/db2/clidriver/adm:/opt/IBM/db2/
 WORKDIR /app
 
 ENTRYPOINT ["/app/docker-entrypoint.sh"]
-CMD ["java", "-jar", "senzing-api-server.jar"]
+CMD ["java", "-jar", "senzing-api-server.jar", "--bind-addr", "all"]


### PR DESCRIPTION
Since this is in a docker image, ingress is controlled via Docker.  Having the only access method to the service inside be bound to localhost doesn't make sense and forces a second bit of unnecessary configuration.
