### PR TITLE
Updated dependabot schedule for standard updates that are not security vulnerabilities

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,4 +14,4 @@ updates:
   - package-ecosystem: "maven"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "monthly"


### PR DESCRIPTION
Changed dependabot schedule to `monthly` instead of `daily`.