### PR TITLE
Version 3.4.7: Fixed the version updates from dependabot to remove runtime warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.7] - 2023-01-04
+
+### Changed in 3.4.7
+
+- Updated dependency versions to newer releases.
+
 ## [3.4.6] - 2022-11-02
 
 ### Changed in 3.4.6

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV REFRESHED_AT=2022-10-27
 
 LABEL Name="senzing/senzing-api-server-builder" \
       Maintainer="support@senzing.com" \
-      Version="3.4.6"
+      Version="3.4.7"
 
 # Set environment variables.
 
@@ -43,7 +43,7 @@ ENV REFRESHED_AT=2022-10-27
 
 LABEL Name="senzing/senzing-api-server" \
       Maintainer="support@senzing.com" \
-      Version="3.4.6"
+      Version="3.4.7"
 
 HEALTHCHECK CMD ["/app/healthcheck.sh"]
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.senzing</groupId>
   <artifactId>senzing-api-server</artifactId>
   <packaging>jar</packaging>
-  <version>3.4.6</version>
+  <version>3.4.7</version>
   <name>senzing-api-server</name>
   <url>http://maven.apache.org</url>
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -216,7 +216,7 @@
     <dependency>
       <groupId>com.sun.xml.bind</groupId>
       <artifactId>jaxb-impl</artifactId>
-      <version>4.0.1</version>
+      <version>2.3.1</version>
     </dependency>
     <dependency>
       <groupId>org.javassist</groupId>
@@ -260,7 +260,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>${maven.compiler.source}</maven.compiler.target>
-    <junit.jupiter.version>5.4.2</junit.jupiter.version>
+    <junit.jupiter.version>5.9.1</junit.jupiter.version>
     <buildDirectory>${project.basedir}/target</buildDirectory>
   </properties>
   <build>
@@ -419,7 +419,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.3.0</version>
+        <version>3.4.1</version>
         <configuration>
           <createDependencyReducedPom>false</createDependencyReducedPom>
           <filters>


### PR DESCRIPTION
- Reverted `jaxb-impl` version from `4.0.1` to `2.3.1` to prevent warning regarding WADL feature 
- Updated JUnit Jupiter version property to 5.9.1 to match actual version
- Updated Maven shade plugin version
