### PR TITLE
Dependabot updates + LICENSEFILE removal from RepositoryManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed in 3.4.12
 
+- Removed `LICENSEFILE` from `g2-init.json` file produced by `RepositoryManager`
 - Updated dependency versions to newer releases.
 
 ## [3.4.11] - 2023-02-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.12] - 2023-02-21
+
+### Changed in 3.4.12
+
+- Updated dependency versions to newer releases.
+
 ## [3.4.11] - 2023-02-09
 
 ### Changed in 3.4.11

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV REFRESHED_AT=2023-01-13
 
 LABEL Name="senzing/senzing-api-server-builder" \
       Maintainer="support@senzing.com" \
-      Version="3.4.11"
+      Version="3.4.12"
 
 # Set environment variables.
 
@@ -43,7 +43,7 @@ ENV REFRESHED_AT=2023-01-13
 
 LABEL Name="senzing/senzing-api-server" \
       Maintainer="support@senzing.com" \
-      Version="3.4.11"
+      Version="3.4.12"
 
 HEALTHCHECK CMD ["/app/healthcheck.sh"]
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.senzing</groupId>
   <artifactId>senzing-api-server</artifactId>
   <packaging>jar</packaging>
-  <version>3.4.11</version>
+  <version>3.4.12</version>
   <name>senzing-api-server</name>
   <url>http://maven.apache.org</url>
   <dependencies>
@@ -21,83 +21,83 @@
     <dependency>
      <groupId>org.xerial</groupId>
      <artifactId>sqlite-jdbc</artifactId>
-       <version>3.40.0.0</version>
+       <version>3.41.0.0</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
-      <version>9.4.50.v20221201</version>
+      <version>9.4.51.v20230217</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlet</artifactId>
-      <version>9.4.50.v20221201</version>
+      <version>9.4.51.v20230217</version>
     </dependency>
     <!-- https://mvnrepository.com/artifact/org.eclipse.jetty/jetty-servlets -->
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlets</artifactId>
-      <version>9.4.50.v20221201</version>
+      <version>9.4.51.v20230217</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-rewrite</artifactId>
-      <version>9.4.50.v20221201</version>
+      <version>9.4.51.v20230217</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-proxy</artifactId>
-      <version>9.4.50.v20221201</version>
+      <version>9.4.51.v20230217</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.websocket</groupId>
       <artifactId>websocket-server</artifactId>
-      <version>9.4.50.v20221201</version>
+      <version>9.4.51.v20230217</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.websocket</groupId>
       <artifactId>websocket-common</artifactId>
-      <version>9.4.50.v20221201</version>
+      <version>9.4.51.v20230217</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.websocket</groupId>
       <artifactId>websocket-servlet</artifactId>
-      <version>9.4.50.v20221201</version>
+      <version>9.4.51.v20230217</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.websocket</groupId>
       <artifactId>javax-websocket-server-impl</artifactId>
-      <version>9.4.50.v20221201</version>
+      <version>9.4.51.v20230217</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.websocket</groupId>
       <artifactId>websocket-api</artifactId>
-      <version>9.4.50.v20221201</version>
+      <version>9.4.51.v20230217</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.core</groupId>
       <artifactId>jersey-server</artifactId>
-      <version>2.37</version>
+      <version>2.39</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.containers</groupId>
       <artifactId>jersey-container-servlet</artifactId>
-      <version>2.37</version>
+      <version>2.39</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-sse</artifactId>
-      <version>2.37</version>
+      <version>2.39</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.containers</groupId>
       <artifactId>jersey-container-servlet-core</artifactId>
-      <version>2.37</version>
+      <version>2.39</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.containers</groupId>
       <artifactId>jersey-container-jetty-http</artifactId>
-      <version>2.37</version>
+      <version>2.39</version>
       <exclusions>
         <exclusion>
           <groupId>org.eclipse.jetty</groupId>
@@ -108,17 +108,17 @@
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-json-jackson</artifactId>
-      <version>2.37</version>
+      <version>2.39</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-multipart</artifactId>
-      <version>2.37</version>
+      <version>2.39</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.inject</groupId>
       <artifactId>jersey-hk2</artifactId>
-      <version>2.37</version>
+      <version>2.39</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
@@ -149,7 +149,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-csv</artifactId>
-      <version>1.9.0</version>
+      <version>1.10.0</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish</groupId>
@@ -164,7 +164,7 @@
     <dependency>
       <groupId>com.ibm.icu</groupId>
       <artifactId>icu4j</artifactId>
-      <version>71.1</version>
+      <version>72.1</version>
     </dependency>
     <dependency>
       <groupId>org.ini4j</groupId>
@@ -174,7 +174,7 @@
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>sqs</artifactId>
-      <version>2.17.280</version>
+      <version>2.20.20</version>
     </dependency>
     <dependency>
       <groupId>com.rabbitmq</groupId>
@@ -184,7 +184,7 @@
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-clients</artifactId>
-      <version>3.3.1</version>
+      <version>3.4.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
@@ -194,12 +194,12 @@
     <dependency>
        <groupId>org.slf4j</groupId>
        <artifactId>slf4j-api</artifactId>
-       <version>2.0.3</version>
+       <version>2.0.6</version>
    </dependency>
    <dependency>
        <groupId>org.slf4j</groupId>
        <artifactId>slf4j-simple</artifactId>
-       <version>2.0.3</version>
+       <version>2.0.6</version>
    </dependency>
 
     <!-- add dependencies that were present in JDK 8, but optional in JDK 11 -->
@@ -240,19 +240,19 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-web</artifactId>
-      <version>[5.3.22,5.9999.9999)</version>
+      <version>[5.3.25,5.9999.9999)</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
-      <version>[5.3.22,5.9999.9999)</version>
+      <version>[5.3.25,5.9999.9999)</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.swagger.core.v3</groupId>
       <artifactId>swagger-annotations</artifactId>
-      <version>2.2.4</version>
+      <version>2.2.8</version>
       <scope>test</scope>
     </dependency>
 </dependencies>

--- a/src/main/java/com/senzing/repomgr/RepositoryManager.java
+++ b/src/main/java/com/senzing/repomgr/RepositoryManager.java
@@ -540,7 +540,6 @@ public class RepositoryManager {
       } else if (CONFIG_DIR != null) {
         subBuilder.add("CONFIGPATH", CONFIG_DIR.toString());
       }
-      subBuilder.add("LICENSEFILE", licensePath.getCanonicalPath());
       builder.add("PIPELINE", subBuilder);
 
       subBuilder = Json.createObjectBuilder();


### PR DESCRIPTION
Version 3.4.12

- Removed `LICENSEFILE` from `g2-init.json` file produced by `RepositoryManager`
- Updated dependency versions to newer releases.
