### PR TITLE
Version 3.5.5: Updates to dependency versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [3.5.5] - 2023-06-30
+
+### Changed in 3.5.5
+
+- Updated `sqlite-jdbc` to version `3.42.0.0`
+- Updated Jersey dependencies to version `2.40`
+- Updated `icu4j` to version `73.2`
+- Updated `sqs` to version `2.20.94`
+- Updated `amqp-client` to version `5.18.0`
+- Updated `kafka-clients` to version `3.5.0`
+
 ## [3.5.4] - 2023-06-29
 
 ### Changed in 3.5.4

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV REFRESHED_AT=2023-06-29
 
 LABEL Name="senzing/senzing-api-server-builder" \
       Maintainer="support@senzing.com" \
-      Version="3.5.4"
+      Version="3.5.5"
 
 # Set environment variables.
 
@@ -43,7 +43,7 @@ ENV REFRESHED_AT=2023-06-29
 
 LABEL Name="senzing/senzing-api-server" \
       Maintainer="support@senzing.com" \
-      Version="3.5.4"
+      Version="3.5.5"
 
 HEALTHCHECK CMD ["/app/healthcheck.sh"]
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <dependency>
      <groupId>org.xerial</groupId>
      <artifactId>sqlite-jdbc</artifactId>
-       <version>3.41.2.1</version>
+       <version>3.42.0.0</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
@@ -97,7 +97,7 @@
     <dependency>
       <groupId>org.glassfish.jersey.containers</groupId>
       <artifactId>jersey-container-jetty-http</artifactId>
-      <version>2.39</version>
+      <version>2.40</version>
       <exclusions>
         <exclusion>
           <groupId>org.eclipse.jetty</groupId>
@@ -108,17 +108,17 @@
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-json-jackson</artifactId>
-      <version>2.39</version>
+      <version>2.40</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-multipart</artifactId>
-      <version>2.39</version>
+      <version>2.40</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.inject</groupId>
       <artifactId>jersey-hk2</artifactId>
-      <version>2.39</version>
+      <version>2.40</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
@@ -164,7 +164,7 @@
     <dependency>
       <groupId>com.ibm.icu</groupId>
       <artifactId>icu4j</artifactId>
-      <version>73.1</version>
+      <version>73.2</version>
     </dependency>
     <dependency>
       <groupId>org.ini4j</groupId>
@@ -174,17 +174,17 @@
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>sqs</artifactId>
-      <version>2.20.20</version>
+      <version>2.20.94</version>
     </dependency>
     <dependency>
       <groupId>com.rabbitmq</groupId>
       <artifactId>amqp-client</artifactId>
-      <version>5.17.0</version>
+      <version>5.18.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-clients</artifactId>
-      <version>3.4.0</version>
+      <version>3.5.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>


### PR DESCRIPTION
- Updated `sqlite-jdbc` to version `3.42.0.0`
- Updated Jersey dependencies to version `2.40`
- Updated `icu4j` to version `73.2`
- Updated `sqs` to version `2.20.94`
- Updated `amqp-client` to version `5.18.0`
- Updated `kafka-clients` to version `3.5.0`
