### PR TITLE
Version 3.5.9 Release in support of new POC Server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.9] - 2023-12-08
+
+### Changed in 3.5.9
+
+- Reverted sqlite-jdbc to 3.42.0.1 because the SQLite team haphazardly removed
+  functionality that has been supported for 16 years.
+- Added method to ServicesSupport for creating InternalServerErrorExceptions
+  with a String message rather than a G2Fallible or another Exception
+- Updated other dependencies to newer versions to match other Senzing projects
+
 ## [3.5.8] - 2023-11-14
 
 ### Changed in 3.5.8

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.senzing</groupId>
   <artifactId>senzing-api-server</artifactId>
   <packaging>jar</packaging>
-  <version>3.5.7</version>
+  <version>3.5.8</version>
   <name>senzing-api-server</name>
   <url>http://maven.apache.org</url>
   <dependencies>
@@ -16,7 +16,7 @@
     <dependency>
       <groupId>com.senzing</groupId>
       <artifactId>senzing-commons</artifactId>
-      <version>[3.0.2, 3.0.9999)</version>
+      <version>[3.1.4, 3.99999.99999)</version>
     </dependency>
     <dependency>
      <groupId>org.xerial</groupId>
@@ -26,78 +26,78 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
-      <version>9.4.52.v20230823</version>
+      <version>9.4.53.v20231009</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlet</artifactId>
-      <version>9.4.52.v20230823</version>
+      <version>9.4.53.v20231009</version>
     </dependency>
     <!-- https://mvnrepository.com/artifact/org.eclipse.jetty/jetty-servlets -->
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlets</artifactId>
-      <version>9.4.52.v20230823</version>
+      <version>9.4.53.v20231009</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-rewrite</artifactId>
-      <version>9.4.52.v20230823</version>
+      <version>9.4.53.v20231009</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-proxy</artifactId>
-      <version>9.4.52.v20230823</version>
+      <version>9.4.53.v20231009</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.websocket</groupId>
       <artifactId>websocket-server</artifactId>
-      <version>9.4.52.v20230823</version>
+      <version>9.4.53.v20231009</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.websocket</groupId>
       <artifactId>websocket-common</artifactId>
-      <version>9.4.52.v20230823</version>
+      <version>9.4.53.v20231009</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.websocket</groupId>
       <artifactId>websocket-servlet</artifactId>
-      <version>9.4.52.v20230823</version>
+      <version>9.4.53.v20231009</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.websocket</groupId>
       <artifactId>javax-websocket-server-impl</artifactId>
-      <version>9.4.52.v20230823</version>
+      <version>9.4.53.v20231009</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.websocket</groupId>
       <artifactId>websocket-api</artifactId>
-      <version>9.4.52.v20230823</version>
+      <version>9.4.53.v20231009</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.core</groupId>
       <artifactId>jersey-server</artifactId>
-      <version>2.40</version>
+      <version>2.41</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.containers</groupId>
       <artifactId>jersey-container-servlet</artifactId>
-      <version>2.40</version>
+      <version>2.41</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-sse</artifactId>
-      <version>2.40</version>
+      <version>2.41</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.containers</groupId>
       <artifactId>jersey-container-servlet-core</artifactId>
-      <version>2.40</version>
+      <version>2.41</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.containers</groupId>
       <artifactId>jersey-container-jetty-http</artifactId>
-      <version>2.40</version>
+      <version>2.41</version>
       <exclusions>
         <exclusion>
           <groupId>org.eclipse.jetty</groupId>
@@ -108,17 +108,17 @@
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-json-jackson</artifactId>
-      <version>2.40</version>
+      <version>2.41</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-multipart</artifactId>
-      <version>2.40</version>
+      <version>2.41</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.inject</groupId>
       <artifactId>jersey-hk2</artifactId>
-      <version>2.40</version>
+      <version>2.41</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
@@ -128,22 +128,22 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.15.2</version>
+      <version>2.15.3</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.15.2</version>
+      <version>2.15.3</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>
       <artifactId>jackson-module-jaxb-annotations</artifactId>
-      <version>2.15.2</version>
+      <version>2.15.3</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>5.9.3</version>
+      <version>5.10.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -164,7 +164,7 @@
     <dependency>
       <groupId>com.ibm.icu</groupId>
       <artifactId>icu4j</artifactId>
-      <version>73.2</version>
+      <version>74.1</version>
     </dependency>
     <dependency>
       <groupId>org.ini4j</groupId>
@@ -174,32 +174,32 @@
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>sqs</artifactId>
-      <version>2.20.140</version>
+      <version>2.21.17</version>
     </dependency>
     <dependency>
       <groupId>com.rabbitmq</groupId>
       <artifactId>amqp-client</artifactId>
-      <version>5.19.0</version>
+      <version>5.20.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-clients</artifactId>
-      <version>3.5.0</version>
+      <version>3.6.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-joda</artifactId>
-      <version>2.15.2</version>
+      <version>2.15.3</version>
     </dependency>
     <dependency>
        <groupId>org.slf4j</groupId>
        <artifactId>slf4j-api</artifactId>
-       <version>2.0.7</version>
+       <version>2.0.9</version>
    </dependency>
    <dependency>
        <groupId>org.slf4j</groupId>
        <artifactId>slf4j-simple</artifactId>
-       <version>2.0.7</version>
+       <version>2.0.9</version>
    </dependency>
 
     <!-- add dependencies that were present in JDK 8, but optional in JDK 11 -->
@@ -234,25 +234,25 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-core</artifactId>
-      <version>[5.3.22,5.9999.9999)</version>
+      <version>[5.3.30,5.9999.9999)</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-web</artifactId>
-      <version>[5.3.25,5.9999.9999)</version>
+      <version>[5.3.30,5.9999.9999)</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
-      <version>[5.3.25,5.9999.9999)</version>
+      <version>[5.3.30,5.9999.9999)</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.swagger.core.v3</groupId>
       <artifactId>swagger-annotations</artifactId>
-      <version>2.2.15</version>
+      <version>2.2.18</version>
       <scope>test</scope>
     </dependency>
 </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>sqs</artifactId>
-      <version>2.21.17</version>
+      <version>2.21.40</version>
     </dependency>
     <dependency>
       <groupId>com.rabbitmq</groupId>
@@ -184,7 +184,7 @@
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-clients</artifactId>
-      <version>3.6.0</version>
+      <version>3.6.1</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.senzing</groupId>
   <artifactId>senzing-api-server</artifactId>
   <packaging>jar</packaging>
-  <version>3.5.8</version>
+  <version>3.5.9</version>
   <name>senzing-api-server</name>
   <url>http://maven.apache.org</url>
   <dependencies>
@@ -21,7 +21,7 @@
     <dependency>
      <groupId>org.xerial</groupId>
      <artifactId>sqlite-jdbc</artifactId>
-       <version>3.43.0.0</version>
+       <version>3.42.0.1</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>

--- a/src/main/java/com/senzing/api/services/ServicesSupport.java
+++ b/src/main/java/com/senzing/api/services/ServicesSupport.java
@@ -203,6 +203,31 @@ public interface ServicesSupport {
   }
 
   /**
+   * Creates an {@link InternalServerErrorException} and builds a response
+   * with an {@link SzErrorResponse} using the specified {@link UriInfo}
+   * and the specified error message.
+   *
+   * @param httpMethod The HTTP method for the request.
+   * @param uriInfo    The {@link UriInfo} from the request.
+   * @param timers     The {@link Timers} object for the timings that were taken.
+   * @param message    The error message describing the error.
+   * @return The {@link InternalServerErrorException}
+   */
+  default InternalServerErrorException newInternalServerErrorException(
+      SzHttpMethod  httpMethod,
+      UriInfo       uriInfo,
+      Timers        timers,
+      String        message) 
+  {
+    Response.ResponseBuilder builder = Response.status(SERVER_ERROR);
+    builder.entity(this.newErrorResponse(
+        this.newMeta(httpMethod, SERVER_ERROR, timers),
+        this.newLinks(uriInfo), message));
+    builder.type(APPLICATION_JSON);
+    return new InternalServerErrorException(builder.build());
+  }
+
+  /**
    * Creates an {@link ServiceUnavailableException} and builds a response
    * with an {@link SzErrorResponse} using the specified {@link UriInfo}
    * and the specified exception.
@@ -211,7 +236,7 @@ public interface ServicesSupport {
    * @param uriInfo    The {@link UriInfo} from the request.
    * @param timers     The {@link Timers} object for the timings that were taken.
    * @param message    The message describing the error.
-   * @return The {@link ServiceUnavailableException}
+   * @return The {@link ServiceUnavailableException} that was created.
    */
   default ServiceUnavailableException newServiceUnavailableErrorException(
       SzHttpMethod httpMethod,
@@ -236,7 +261,7 @@ public interface ServicesSupport {
    * @param uriInfo    The {@link UriInfo} from the request.
    * @param timers     The {@link Timers} object for the timings that were taken.
    * @param fallible   The {@link G2Fallible} to get the last exception from.
-   * @return The {@link InternalServerErrorException}
+   * @return The {@link InternalServerErrorException} that was created.
    */
   default InternalServerErrorException newInternalServerErrorException(
       SzHttpMethod httpMethod,
@@ -264,7 +289,7 @@ public interface ServicesSupport {
    * @param uriInfo    The {@link UriInfo} from the request.
    * @param timers     The {@link Timers} object for the timings that were taken.
    * @param fallible   The {@link G2Fallible} to get the last exception from.
-   * @return The {@link InternalServerErrorException}
+   * @return The {@link NotFoundException} that was created.
    */
   default NotFoundException newNotFoundException(
       SzHttpMethod httpMethod,
@@ -287,7 +312,7 @@ public interface ServicesSupport {
    * @param httpMethod The HTTP method for the request.
    * @param uriInfo    The {@link UriInfo} from the request.
    * @param timers     The {@link Timers} object for the timings that were taken.
-   * @return The {@link InternalServerErrorException}
+   * @return The {@link NotFoundException} that was created.
    */
   default NotFoundException newNotFoundException(
       SzHttpMethod httpMethod,
@@ -309,7 +334,7 @@ public interface ServicesSupport {
    * @param uriInfo      The {@link UriInfo} from the request.
    * @param timers       The {@link Timers} object for the timings that were taken.
    * @param errorMessage The error message.
-   * @return The {@link InternalServerErrorException}
+   * @return The {@link NotFoundException} that was created.
    */
   default NotFoundException newNotFoundException(
       SzHttpMethod httpMethod,
@@ -332,7 +357,7 @@ public interface ServicesSupport {
    * @param uriInfo      The {@link UriInfo} from the request.
    * @param timers       The {@link Timers} object for the timings that were taken.
    * @param errorMessage The error message.
-   * @return The {@link InternalServerErrorException}
+   * @return The {@link NotAllowedException} that was created.
    */
   default NotAllowedException newNotAllowedException(
       SzHttpMethod httpMethod,
@@ -397,7 +422,7 @@ public interface ServicesSupport {
   }
 
   /**
-   * Creates an {@link InternalServerErrorException} and builds a response
+   * Creates an {@link BadRequestException} and builds a response
    * with an {@link SzErrorResponse} using the specified {@link UriInfo}
    * and the specified exception.
    *
@@ -405,7 +430,7 @@ public interface ServicesSupport {
    * @param uriInfo    The {@link UriInfo} from the request.
    * @param timers     The {@link Timers} object for the timings that were taken.
    * @param exception  The exception that caused the error.
-   * @return The {@link InternalServerErrorException}
+   * @return The {@link BadRequestException} that was created.
    */
   default BadRequestException newBadRequestException(
       SzHttpMethod httpMethod,
@@ -456,7 +481,7 @@ public interface ServicesSupport {
    * @param timers     The {@link Timers} object for the timings that were taken.
    * @param engineApi  The {@link G2Fallible} to get the last exception from.
    * @return A newly created {@link NotFoundException} or {@link
-   * InternalServerErrorException}.
+   *         InternalServerErrorException}.
    */
   default WebApplicationException newPossiblyNotFoundException(
       SzHttpMethod httpMethod,


### PR DESCRIPTION
- Reverted sqlite-jdbc to 3.42.0.1 because the SQLite team haphazardly removed functionality that has been supported for 16 years.
- Added method to ServicesSupport for creating InternalServerErrorExceptions with a String message rather than a G2Fallible or another Exception
- Updated other dependencies to newer versions to match other Senzing projects
